### PR TITLE
set max retries

### DIFF
--- a/spec/runtime/handlers/defineQueue.spec.ts
+++ b/spec/runtime/handlers/defineQueue.spec.ts
@@ -26,7 +26,7 @@ describe('defineQueue', () => {
     const queue = defineQueue({ name: 'email', options: { defaultJobOptions: { attempts: 1 } } })
 
     expect(queue.name).toBe('email')
-    expect((queue).opts.connection).toEqual(connection)
+    expect((queue).opts.connection).toEqual(expect.objectContaining(connection))
 
     await api.stopAll()
   })

--- a/spec/runtime/handlers/defineWorker.spec.ts
+++ b/spec/runtime/handlers/defineWorker.spec.ts
@@ -30,7 +30,7 @@ describe('defineWorker', () => {
     const worker = defineWorker({ name: 'email', processor: async () => {}, options: { concurrency: 2 } })
 
     expect(worker.name).toBe('email')
-    expect((worker).opts.connection).toEqual(connection)
+    expect((worker).opts.connection).toEqual(expect.objectContaining(connection))
     expect((worker).opts.autorun).toBe(false)
 
     await api.stopAll()

--- a/spec/runtime/utils/workers.spec.ts
+++ b/spec/runtime/utils/workers.spec.ts
@@ -61,9 +61,11 @@ describe('$workers registry', () => {
     const worker = api.createWorker('test-queue', async () => {}, { concurrency: 3 })
 
     expect(queue.name).toBe('test-queue')
-    expect((queue.opts.connection)).toEqual(connection)
+    expect((queue.opts.connection)).toEqual(expect.objectContaining(connection))
+    expect((queue.opts.connection as unknown as { maxRetriesPerRequest: unknown }).maxRetriesPerRequest).toBeNull()
     expect(worker.name).toBe('test-queue')
-    expect((worker).opts.connection).toEqual(connection)
+    expect((worker).opts.connection).toEqual(expect.objectContaining(connection))
+    expect(((worker).opts.connection as unknown as { maxRetriesPerRequest: unknown }).maxRetriesPerRequest).toBeNull()
     expect((worker).opts.autorun).toBe(false)
 
     expect(api.queues).toContain(queue)
@@ -82,12 +84,12 @@ describe('$workers registry', () => {
     const worker = api.createWorker('q1', async () => {})
 
     expect(ioredisConstructorMock).toHaveBeenCalledTimes(1)
-    expect(ioredisConstructorMock).toHaveBeenCalledWith('redis://user:pass@localhost:6379/0')
+    expect(ioredisConstructorMock).toHaveBeenCalledWith('redis://user:pass@localhost:6379/0', expect.objectContaining({ maxRetriesPerRequest: null }))
     expect((queue).opts.connection).toBeDefined()
     expect((worker).opts.connection).toBeDefined()
   })
 
-  it('uses IORedis when given an object with url property, passing rest as options', async () => {
+  it('uses IORedis when given an object with url property, passing rest as options and setting maxRetriesPerRequest=null', async () => {
     const api = $workers()
     api.setConnection({ url: 'redis://localhost:6379/0', password: 'secret', db: 1 })
 
@@ -95,7 +97,7 @@ describe('$workers registry', () => {
     const worker = api.createWorker('q2', async () => {})
 
     expect(ioredisConstructorMock).toHaveBeenCalledTimes(1)
-    expect(ioredisConstructorMock).toHaveBeenCalledWith('redis://localhost:6379/0', { password: 'secret', db: 1 })
+    expect(ioredisConstructorMock).toHaveBeenCalledWith('redis://localhost:6379/0', expect.objectContaining({ password: 'secret', db: 1, maxRetriesPerRequest: null }))
     expect((queue).opts.connection).toBeDefined()
     expect((worker).opts.connection).toBeDefined()
   })

--- a/src/runtime/server/utils/workers.ts
+++ b/src/runtime/server/utils/workers.ts
@@ -21,13 +21,16 @@ export function $workers() {
   function setConnection(connection: ConnectionInput) {
     if (connection && typeof connection === 'object' && 'url' in connection && connection.url) {
       const { url, ...rest } = connection as { url: string } & IORedisOptions
-      registry.connection = new IORedis(url, rest)
+      const opts: IORedisOptions = { ...rest, maxRetriesPerRequest: null }
+      registry.connection = new IORedis(url, opts)
     }
     else if (typeof connection === 'string') {
-      registry.connection = new IORedis(connection)
+      registry.connection = new IORedis(connection, { maxRetriesPerRequest: null })
     }
     else {
-      registry.connection = connection as QueueOptions['connection']
+      // When passing raw options, ensure BullMQ-required setting
+      const normalized = { ...(connection as IORedisOptions), maxRetriesPerRequest: null } as IORedisOptions
+      registry.connection = normalized as unknown as QueueOptions['connection']
     }
   }
 


### PR DESCRIPTION
## Summary

Sets maxRetriesPerRequest to null by default

## Changes

- maxRetriesPerRequest is now null by default

## How to Test

1. Run workers

## Screenshots (optional)

n/a

## Linked Issues

Closes #

## Checklist

- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated docs (README/docs) if needed
- [x] `npm run lint` and `npm test` pass
- [x] No breaking changes, or I documented them above

