### PR TITLE
add generic type support for queues and workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Create `server/queues/hello.ts`:
 ```ts
 import { defineQueue } from '#processor'
 
-export default defineQueue({
+type HelloName = 'hello'
+type HelloData = { message: string, ts: number }
+type HelloResult = { echoed: string, processedAt: number }
+
+export default defineQueue<HelloData, HelloResult, HelloName>({
   name: 'hello',
   options: {},
 })
@@ -77,14 +81,15 @@ Create `server/workers/hello.ts`:
 
 ```ts
 import { defineWorker } from '#processor'
-import type { Job } from '#bullmq'
 
-export default defineWorker({
+type HelloName = 'hello'
+type HelloData = { message: string, ts: number }
+type HelloResult = { echoed: string, processedAt: number }
+
+export default defineWorker<HelloName, HelloData, HelloResult>({
   name: 'hello',
-  async processor(job: Job) {
-    // do work
-    console.log('processed', job.name, job.data)
-    return job.data
+  async processor(job) {
+    return { echoed: job.data.message, processedAt: job.data.ts }
   },
   options: {},
 })

--- a/docs/bull-board.md
+++ b/docs/bull-board.md
@@ -1,0 +1,17 @@
+---
+title: Bull Board
+---
+
+# Bull Board
+
+[Bull Board](https://github.com/felixmosh/bull-board) is an excellent UI for watching your queues.
+
+This project’s playground shows a simple integration using the H3 adapter.
+
+- Server handler: `playground/server/handlers/bull-board.ts`
+- Route: `playground/server/routes/bull-board.ts`
+- Catch-all route: `playground/server/routes/bull-board/[...].ts`
+
+Special thanks to [@genu](https://github.com/genu) for creating the H3 adapter.
+
+For more help getting set up, see this Bull Board H3 adapter comment: <https://github.com/felixmosh/bull-board/pull/669#issuecomment-1883997968>.

--- a/docs/define-queue.md
+++ b/docs/define-queue.md
@@ -10,6 +10,8 @@ title: Define Queue
 
 Create `server/queues/index.ts`:
 
+The `options` are forwarded to BullMQ's `Queue` constructor, except `connection` which is managed by the module.
+
 ```ts
 import { defineQueue } from '#processor'
 
@@ -22,12 +24,31 @@ export default defineQueue({
 ## API
 
 ```ts
-type DefineQueueArgs = {
-  name: string
+type DefineQueueArgs<DefaultNameType extends string = string> = {
+  name: DefaultNameType
   options?: Omit<QueueOptions, 'connection'> & { defaultJobOptions?: JobsOptions }
 }
+
+declare function defineQueue<
+  DataTypeOrJob = any,
+  DefaultResultType = any,
+  DefaultNameType extends string = string,
+>(args: DefineQueueArgs<DefaultNameType>): Queue<DataTypeOrJob, DefaultResultType, DefaultNameType>
 ```
 
-The `options` are forwarded to BullMQ's `Queue` constructor, except `connection` which is managed by the module.
+### Typed example
 
+```ts
+import { defineQueue } from '#processor'
 
+type HelloName = 'hello'
+type HelloData = { message: string, ts: number }
+type HelloResult = { echoed: string, processedAt: number }
+
+export default defineQueue<HelloData, HelloResult, HelloName>({
+  name: 'hello',
+})
+
+// Later in your app code, add a job with fully-typed name and data
+await queue.add('hello', { message: 'hi', ts: Date.now() })
+```

--- a/docs/define-worker.md
+++ b/docs/define-worker.md
@@ -10,6 +10,8 @@ title: Define Worker
 
 Create `server/workers/index.ts`:
 
+The `options` are forwarded to BullMQ's `Worker` constructor, except `connection` which is managed by the module.
+
 ```ts
 import { defineWorker } from '#processor'
 import type { Job } from '#bullmq'
@@ -28,13 +30,33 @@ export default defineWorker({
 ## API
 
 ```ts
-type DefineWorkerArgs = {
-  name: string
-  processor: Processor
+type DefineWorkerArgs<NameType extends string = string, DataType = unknown, ResultType = unknown> = {
+  name: NameType
+  processor: Processor<DataType, ResultType, NameType>
   options?: Omit<WorkerOptions, 'connection'>
 }
+
+declare function defineWorker<
+  NameType extends string = string,
+  DataType = unknown,
+  ResultType = unknown,
+>(args: DefineWorkerArgs<NameType, DataType, ResultType>): Worker<DataType, ResultType, NameType>
 ```
 
-The `options` are forwarded to BullMQ's `Worker` constructor, except `connection` which is managed by the module.
+### Typed example
 
+```ts
+import { defineWorker } from '#processor'
 
+type HelloName = 'hello'
+type HelloData = { message: string, ts: number }
+type HelloResult = { echoed: string, processedAt: number }
+
+export default defineWorker<HelloName, HelloData, HelloResult>({
+  name: 'hello',
+  async processor(job) {
+    const { message, ts } = job.data
+    return { echoed: message, processedAt: ts }
+  },
+})
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,14 +106,6 @@ node .output/server/workers/index.mjs
 
 ## Bull Board
 
-[Bull Board](https://github.com/felixmosh/bull-board) is an excellent UI for watching your queues.
-
-- [Server handler](../playground/server/handlers/bull-board.ts)
-- [Route: `playground/server/routes/bull-board.ts`](../playground/server/routes/bull-board.ts)
-- [Route: `playground/server/routes/bull-board/[...].ts`](../playground/server/routes/bull-board/%5B...%5D.ts)
-
-Special thanks to [@genu](https://github.com/genu) for creating the H3 adapter.
-
-For more help getting set up, see this Bull Board H3 adapter comment: <https://github.com/felixmosh/bull-board/pull/669#issuecomment-1883997968>.
+See the dedicated page: [Bull Board](/bull-board)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ hero:
     - theme: alt
       text: Define a Worker
       link: /define-worker
+    - theme: alt
+      text: Bull Board
+      link: /bull-board
 
 features:
   - title: "🚀 Dedicated processing"

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,8 @@
 export default defineNuxtConfig({
   modules: ['../src/module'],
   devtools: { enabled: true },
+  typescript: {
+    strict: true,
+    typeCheck: true,
+  },
 })

--- a/playground/server/queues/index.ts
+++ b/playground/server/queues/index.ts
@@ -1,6 +1,10 @@
 import { defineQueue } from '#processor'
 
-const queue = defineQueue({
+type HelloName = 'hello'
+type HelloData = { message: string, ts: number }
+type HelloResult = { echoed: string, processedAt: number }
+
+const queue = defineQueue<HelloData, HelloResult, HelloName>({
   name: 'hello',
 })
 

--- a/playground/server/routes/bull-board.ts
+++ b/playground/server/routes/bull-board.ts
@@ -1,3 +1,4 @@
+import { defineEventHandler } from 'h3'
 import { redirectToBullboard } from '../handlers/bull-board'
 
 export default defineEventHandler(redirectToBullboard)

--- a/playground/server/routes/bull-board/[...].ts
+++ b/playground/server/routes/bull-board/[...].ts
@@ -1,3 +1,4 @@
+import { defineEventHandler } from 'h3'
 import { redirectToBullboard } from '../../handlers/bull-board'
 
 export default defineEventHandler(redirectToBullboard)

--- a/playground/server/workers/index.ts
+++ b/playground/server/workers/index.ts
@@ -1,10 +1,14 @@
 import { defineWorker } from '#processor'
-import type { Job } from 'bullmq'
 
-export default defineWorker({
+type HelloName = 'hello'
+type HelloData = { message: string, ts: number }
+type HelloResult = { echoed: string, processedAt: number }
+
+export default defineWorker<HelloName, HelloData, HelloResult>({
   name: 'hello',
-  async processor(job: Job) {
-    return job.data
+  async processor(job) {
+    const { message, ts } = job.data
+    return { echoed: message, processedAt: ts }
   },
   options: {},
 })

--- a/spec/runtime/handlers/defineQueue.spec.ts
+++ b/spec/runtime/handlers/defineQueue.spec.ts
@@ -12,6 +12,7 @@ vi.mock('bullmq', () => {
       this.opts = opts
     }
 
+    add = vi.fn().mockResolvedValue(undefined)
     close = vi.fn().mockResolvedValue(undefined)
   }
   return { Queue: MockQueue }
@@ -27,6 +28,23 @@ describe('defineQueue', () => {
 
     expect(queue.name).toBe('email')
     expect((queue).opts.connection).toEqual(expect.objectContaining(connection))
+
+    await api.stopAll()
+  })
+
+  it('supports typed name, data and result through generics', async () => {
+    const api = $workers()
+    api.setConnection({ host: 'localhost', port: 6379 })
+
+    type Name = 'hello'
+    type Data = { z: number }
+    type Result = { ok: boolean }
+
+    const queue = defineQueue<Data, Result, Name>({ name: 'hello' })
+
+    // .add signature should be strongly typed
+    await queue.add('hello', { z: 1 })
+    // Type-level checks focus on .add payload/name
 
     await api.stopAll()
   })

--- a/spec/runtime/handlers/defineWorker.spec.ts
+++ b/spec/runtime/handlers/defineWorker.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, expectTypeOf } from 'vitest'
 
 import { defineWorker } from '../../../src/runtime/server/handlers/defineWorker'
 import { $workers, type Processor } from '../../../src/runtime/server/utils/workers'
@@ -33,6 +33,27 @@ describe('defineWorker', () => {
     expect((worker).opts.connection).toEqual(expect.objectContaining(connection))
     expect((worker).opts.autorun).toBe(false)
 
+    await api.stopAll()
+  })
+
+  it('supports typed name, data and result through generics', async () => {
+    const api = $workers()
+    api.setConnection({ host: 'localhost', port: 6379 })
+
+    type Name = 'hello'
+    type Data = { x: number }
+    type Result = { y: string }
+
+    const _worker = defineWorker<Name, Data, Result>({
+      name: 'hello',
+      async processor(job) {
+        expectTypeOf(job.name).toEqualTypeOf<Name>()
+        expectTypeOf(job.data).toEqualTypeOf<Data>()
+        return { y: String(job.data.x) }
+      },
+    })
+
+    // Worker instance .name is exposed as string by BullMQ; type-level checks are done via job
     await api.stopAll()
   })
 })

--- a/src/runtime/server/handlers/defineQueue.ts
+++ b/src/runtime/server/handlers/defineQueue.ts
@@ -1,14 +1,20 @@
 import type { Queue, QueueOptions, JobsOptions } from '../utils/workers'
 import { $workers } from '../utils/workers'
 
-type DefineQueueArgs = {
-  name: Queue['name']
+type DefineQueueArgs<DefaultNameType extends string = string> = {
+  name: DefaultNameType
   options?: Omit<QueueOptions, 'connection'> & { defaultJobOptions?: JobsOptions }
 }
 
-export function defineQueue({ name, options }: DefineQueueArgs): Queue {
+export function defineQueue<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DataTypeOrJob = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DefaultResultType = any,
+  DefaultNameType extends string = string,
+>({ name, options }: DefineQueueArgs<DefaultNameType>): Queue<DataTypeOrJob, DefaultResultType, DefaultNameType> {
   const { createQueue } = $workers()
-  return createQueue(name, options)
+  return createQueue<DataTypeOrJob, DefaultResultType, DefaultNameType>(name, options)
 }
 
 export default defineQueue

--- a/src/runtime/server/handlers/defineWorker.ts
+++ b/src/runtime/server/handlers/defineWorker.ts
@@ -1,16 +1,20 @@
 import type { Worker, WorkerOptions, Processor } from 'bullmq'
 import { $workers } from '../utils/workers'
 
-type DefineWorkerArgs = {
-  name: Worker['name']
-  processor: Processor
+type DefineWorkerArgs<NameType extends string = string, DataType = unknown, ResultType = unknown> = {
+  name: NameType
+  processor: Processor<DataType, ResultType, NameType>
   options?: Omit<WorkerOptions, 'connection'>
 }
 
-export function defineWorker(args: DefineWorkerArgs): Worker {
+export function defineWorker<
+  NameType extends string = string,
+  DataType = unknown,
+  ResultType = unknown,
+>(args: DefineWorkerArgs<NameType, DataType, ResultType>): Worker<DataType, ResultType, NameType> {
   const { name, options, processor } = args
   const { createWorker } = $workers()
-  return createWorker(name, processor, options)
+  return createWorker<DataType, ResultType, NameType>(name, processor, options)
 }
 
 export default defineWorker


### PR DESCRIPTION
## Summary

Adds generic type support to queues, and workers.

## Changes

- Adds generics
- Splits bull-board into its own page in docs

## How to Test

1. Create workers and queues using new type definition

## Screenshots (optional)

n/a

## Linked Issues

Closes #

## Checklist

- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated docs (README/docs) if needed
- [x] `npm run lint` and `npm test` pass
- [x] No breaking changes, or I documented them above

