### PR TITLE
Runtime Environment Variables support

### DIFF
--- a/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
+++ b/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
@@ -1,16 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generate-workers-entry-content > matches snapshot for multiple workers and redis url 1`] = `
+exports[`generate-workers-entry-content > matches snapshot for multiple workers and redis config 1`] = `
 "
 import { fileURLToPath } from 'node:url'
 import { resolve as resolvePath } from 'node:path'
 import { consola } from 'consola'
 import { $workers } from '#processor-utils'
+import { resolveRedisConnection } from '#resolve-redis'
 
 // Initialize connection as early as possible so any imports that register
 // workers/queues have a valid connection available.
 const api = $workers()
-api.setConnection(new (await import("ioredis")).default("redis://localhost:6379"))
+api.setConnection(resolveRedisConnection({"host":"localhost","port":6379}))
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)
@@ -108,17 +109,18 @@ export default { createWorkersApp }
 "
 `;
 
-exports[`generate-workers-entry-content > matches snapshot for single worker and undefined redis 1`] = `
+exports[`generate-workers-entry-content > matches snapshot for single worker and empty redis config 1`] = `
 "
 import { fileURLToPath } from 'node:url'
 import { resolve as resolvePath } from 'node:path'
 import { consola } from 'consola'
 import { $workers } from '#processor-utils'
+import { resolveRedisConnection } from '#resolve-redis'
 
 // Initialize connection as early as possible so any imports that register
 // workers/queues have a valid connection available.
 const api = $workers()
-api.setConnection(undefined)
+api.setConnection(resolveRedisConnection({}))
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)

--- a/spec/utils/generate-redis-connection-expr.spec.ts
+++ b/spec/utils/generate-redis-connection-expr.spec.ts
@@ -56,10 +56,12 @@ describe('resolveRedisConnection', () => {
     }
   })
 
+  // --- basic resolution ---
+
   it('returns static config when no env vars are set', () => {
     const result = resolveRedisConnection({ host: '10.0.0.1', port: 6380, password: 'secret', db: 2 })
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       host: '10.0.0.1',
       port: 6380,
       password: 'secret',
@@ -70,12 +72,27 @@ describe('resolveRedisConnection', () => {
     })
   })
 
+  it('falls back to defaults when both static and env are empty', () => {
+    const result = resolveRedisConnection({})
+
+    expect(result).toMatchObject({
+      host: '127.0.0.1',
+      port: 6379,
+      password: '',
+      username: undefined,
+      db: 0,
+      lazyConnect: undefined,
+      connectTimeout: undefined,
+    })
+  })
+
+  // --- url handling ---
+
   it('includes url in returned object when NUXT_REDIS_URL is set', () => {
     process.env.NUXT_REDIS_URL = 'redis://prod-host:6379/1'
     const result = resolveRedisConnection({ host: '127.0.0.1', port: 6379 })
 
     expect(result).toMatchObject({ url: 'redis://prod-host:6379/1' })
-    // Other options are still present alongside url
     expect(result).toHaveProperty('host')
     expect(result).toHaveProperty('port')
   })
@@ -87,6 +104,39 @@ describe('resolveRedisConnection', () => {
     expect(result).toHaveProperty('host', '127.0.0.1')
   })
 
+  it('NUXT_REDIS_URL env takes priority over static url', () => {
+    process.env.NUXT_REDIS_URL = 'redis://env-host:6379'
+    const result = resolveRedisConnection({ url: 'redis://config-host:6379' })
+
+    expect(result).toMatchObject({ url: 'redis://env-host:6379' })
+  })
+
+  it('does not include url key when no url is provided', () => {
+    const result = resolveRedisConnection({ host: '10.0.0.1' })
+
+    expect(result).not.toHaveProperty('url')
+  })
+
+  it('preserves all options alongside url for setConnection', () => {
+    process.env.NUXT_REDIS_URL = 'redis://prod:6379'
+    process.env.NUXT_REDIS_PASSWORD = 'prod-pw'
+
+    const result = resolveRedisConnection({ host: '127.0.0.1', connectTimeout: 10000 })
+
+    expect(result).toMatchObject({
+      url: 'redis://prod:6379',
+      host: '127.0.0.1',
+      port: 6379,
+      password: 'prod-pw',
+      username: undefined,
+      db: 0,
+      lazyConnect: undefined,
+      connectTimeout: 10000,
+    })
+  })
+
+  // --- env overrides ---
+
   it('env vars override individual static fields', () => {
     process.env.NUXT_REDIS_HOST = '192.168.1.100'
     process.env.NUXT_REDIS_PORT = '6381'
@@ -96,7 +146,7 @@ describe('resolveRedisConnection', () => {
 
     const result = resolveRedisConnection({ host: '10.0.0.1', port: 6380, password: 'build-pw', db: 2 })
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       host: '192.168.1.100',
       port: 6381,
       password: 'runtime-pw',
@@ -120,13 +170,6 @@ describe('resolveRedisConnection', () => {
     })
   })
 
-  it('NUXT_REDIS_URL env takes priority over static url', () => {
-    process.env.NUXT_REDIS_URL = 'redis://env-host:6379'
-    const result = resolveRedisConnection({ url: 'redis://config-host:6379' })
-
-    expect(result).toMatchObject({ url: 'redis://env-host:6379' })
-  })
-
   it('handles lazyConnect and connectTimeout from env', () => {
     process.env.NUXT_REDIS_LAZY_CONNECT = 'true'
     process.env.NUXT_REDIS_CONNECT_TIMEOUT = '5000'
@@ -139,41 +182,94 @@ describe('resolveRedisConnection', () => {
     })
   })
 
-  it('falls back to defaults when both static and env are empty', () => {
+  // --- extra keys preserved ---
+
+  it('preserves extra IORedis keys from staticConfig (tls, sentinels, etc.)', () => {
+    const tlsOpts = { rejectUnauthorized: false }
+    const result = resolveRedisConnection({
+      host: '10.0.0.1',
+      tls: tlsOpts,
+      enableReadyCheck: true,
+      family: 4,
+    })
+
+    expect(result).toMatchObject({
+      host: '10.0.0.1',
+      tls: tlsOpts,
+      enableReadyCheck: true,
+      family: 4,
+    })
+  })
+
+  it('env overrides do not strip extra keys', () => {
+    process.env.NUXT_REDIS_HOST = 'override-host'
+
+    const result = resolveRedisConnection({
+      host: 'old-host',
+      tls: { ca: 'cert' },
+      retryStrategy: 'keep-me',
+    })
+
+    expect(result.host).toBe('override-host')
+    expect(result).toHaveProperty('tls')
+    expect(result).toHaveProperty('retryStrategy', 'keep-me')
+  })
+
+  // --- NaN / invalid numeric fallback ---
+
+  it('falls back to static port when NUXT_REDIS_PORT is not a number', () => {
+    process.env.NUXT_REDIS_PORT = 'abc'
+
+    const result = resolveRedisConnection({ port: 6380 })
+    expect(result.port).toBe(6380)
+  })
+
+  it('falls back to default port (6379) when both env and static are invalid', () => {
+    process.env.NUXT_REDIS_PORT = 'notanumber'
+
     const result = resolveRedisConnection({})
-
-    expect(result).toEqual({
-      host: '127.0.0.1',
-      port: 6379,
-      password: '',
-      username: undefined,
-      db: 0,
-      lazyConnect: undefined,
-      connectTimeout: undefined,
-    })
+    expect(result.port).toBe(6379)
   })
 
-  it('does not include url key when no url is provided', () => {
-    const result = resolveRedisConnection({ host: '10.0.0.1' })
+  it('falls back to static db when NUXT_REDIS_DB is not a number', () => {
+    process.env.NUXT_REDIS_DB = 'xyz'
 
-    expect(result).not.toHaveProperty('url')
+    const result = resolveRedisConnection({ db: 3 })
+    expect(result.db).toBe(3)
   })
 
-  it('preserves all options alongside url for setConnection', () => {
-    process.env.NUXT_REDIS_URL = 'redis://prod:6379'
-    process.env.NUXT_REDIS_PASSWORD = 'prod-pw'
+  it('falls back to static connectTimeout when env value is invalid', () => {
+    process.env.NUXT_REDIS_CONNECT_TIMEOUT = 'bad'
 
-    const result = resolveRedisConnection({ host: '127.0.0.1', connectTimeout: 10000 })
+    const result = resolveRedisConnection({ connectTimeout: 8000 })
+    expect(result.connectTimeout).toBe(8000)
+  })
 
-    expect(result).toEqual({
-      url: 'redis://prod:6379',
-      host: '127.0.0.1',
-      port: 6379,
-      password: 'prod-pw',
-      username: undefined,
-      db: 0,
-      lazyConnect: undefined,
-      connectTimeout: 10000,
-    })
+  // --- lazyConnect explicit parsing ---
+
+  it('sets lazyConnect true when env is "true"', () => {
+    process.env.NUXT_REDIS_LAZY_CONNECT = 'true'
+
+    const result = resolveRedisConnection({ lazyConnect: false })
+    expect(result.lazyConnect).toBe(true)
+  })
+
+  it('sets lazyConnect false when env is "false"', () => {
+    process.env.NUXT_REDIS_LAZY_CONNECT = 'false'
+
+    const result = resolveRedisConnection({ lazyConnect: true })
+    expect(result.lazyConnect).toBe(false)
+  })
+
+  it('keeps static lazyConnect when env value is unrecognised', () => {
+    process.env.NUXT_REDIS_LAZY_CONNECT = 'banana'
+
+    const result = resolveRedisConnection({ lazyConnect: true })
+    expect(result.lazyConnect).toBe(true)
+  })
+
+  it('keeps static lazyConnect when env is not set', () => {
+    const result = resolveRedisConnection({ lazyConnect: true })
+    expect(result.lazyConnect).toBe(true)
   })
 })

--- a/spec/utils/generate-redis-connection-expr.spec.ts
+++ b/spec/utils/generate-redis-connection-expr.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { generateRedisConnectionExpr } from '../../src/utils/generate-redis-connection-expr'
+
+// Helper: evaluate the generated expression in current process context
+function evalExpr(expr: string): unknown {
+  return eval(expr)
+}
+
+function clearEnvKey(key: string) {
+  Reflect.deleteProperty(process.env, key)
+}
+
+describe('generateRedisConnectionExpr', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+  const envKeys = [
+    'NUXT_REDIS_URL',
+    'NUXT_REDIS_HOST',
+    'NUXT_REDIS_PORT',
+    'NUXT_REDIS_PASSWORD',
+    'NUXT_REDIS_USERNAME',
+    'NUXT_REDIS_DB',
+    'NUXT_REDIS_LAZY_CONNECT',
+    'NUXT_REDIS_CONNECT_TIMEOUT',
+  ]
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key]
+      clearEnvKey(key)
+    }
+  })
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key]
+      }
+      else {
+        clearEnvKey(key)
+      }
+    }
+  })
+
+  it('returns static config when no env vars are set', () => {
+    const staticRedis = JSON.stringify({ host: '10.0.0.1', port: 6380, password: 'secret', db: 2 })
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr) as Record<string, unknown>
+
+    expect(result).toEqual({
+      host: '10.0.0.1',
+      port: 6380,
+      password: 'secret',
+      username: undefined,
+      db: 2,
+      lazyConnect: undefined,
+      connectTimeout: undefined,
+    })
+  })
+
+  it('returns NUXT_REDIS_URL when set at runtime', () => {
+    process.env.NUXT_REDIS_URL = 'redis://prod-host:6379/1'
+    const staticRedis = JSON.stringify({ host: '127.0.0.1', port: 6379 })
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr)
+
+    expect(result).toBe('redis://prod-host:6379/1')
+  })
+
+  it('returns static url when set in config and no env url', () => {
+    const staticRedis = JSON.stringify({ url: 'redis://config-host:6379/0', host: '127.0.0.1' })
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr)
+
+    expect(result).toBe('redis://config-host:6379/0')
+  })
+
+  it('env vars override individual static fields', () => {
+    process.env.NUXT_REDIS_HOST = '192.168.1.100'
+    process.env.NUXT_REDIS_PORT = '6381'
+    process.env.NUXT_REDIS_PASSWORD = 'runtime-pw'
+    process.env.NUXT_REDIS_USERNAME = 'admin'
+    process.env.NUXT_REDIS_DB = '5'
+
+    const staticRedis = JSON.stringify({ host: '10.0.0.1', port: 6380, password: 'build-pw', db: 2 })
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr) as Record<string, unknown>
+
+    expect(result).toEqual({
+      host: '192.168.1.100',
+      port: 6381,
+      password: 'runtime-pw',
+      username: 'admin',
+      db: 5,
+      lazyConnect: undefined,
+      connectTimeout: undefined,
+    })
+  })
+
+  it('env vars partially override static fields', () => {
+    process.env.NUXT_REDIS_HOST = 'new-host'
+    // port, password etc. not set in env
+
+    const staticRedis = JSON.stringify({ host: '10.0.0.1', port: 6380, password: 'build-pw', db: 2 })
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr) as Record<string, unknown>
+
+    expect(result).toMatchObject({
+      host: 'new-host',
+      port: 6380,
+      password: 'build-pw',
+      db: 2,
+    })
+  })
+
+  it('NUXT_REDIS_URL env takes priority over static url in config', () => {
+    process.env.NUXT_REDIS_URL = 'redis://env-host:6379'
+    const staticRedis = JSON.stringify({ url: 'redis://config-host:6379' })
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr)
+
+    expect(result).toBe('redis://env-host:6379')
+  })
+
+  it('handles lazyConnect and connectTimeout from env', () => {
+    process.env.NUXT_REDIS_LAZY_CONNECT = 'true'
+    process.env.NUXT_REDIS_CONNECT_TIMEOUT = '5000'
+
+    const staticRedis = JSON.stringify({})
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr) as Record<string, unknown>
+
+    expect(result).toMatchObject({
+      lazyConnect: true,
+      connectTimeout: 5000,
+    })
+  })
+
+  it('falls back to defaults when both static and env are empty', () => {
+    const staticRedis = JSON.stringify({})
+    const expr = generateRedisConnectionExpr(staticRedis)
+    const result = evalExpr(expr) as Record<string, unknown>
+
+    expect(result).toEqual({
+      host: '127.0.0.1',
+      port: 6379,
+      password: '',
+      username: undefined,
+      db: 0,
+      lazyConnect: undefined,
+      connectTimeout: undefined,
+    })
+  })
+
+  it('generated expression contains process.env references', () => {
+    const expr = generateRedisConnectionExpr('{}')
+    expect(expr).toContain('process.env.NUXT_REDIS_URL')
+    expect(expr).toContain('process.env.NUXT_REDIS_HOST')
+    expect(expr).toContain('process.env.NUXT_REDIS_PORT')
+    expect(expr).toContain('process.env.NUXT_REDIS_PASSWORD')
+  })
+})

--- a/spec/utils/generate-workers-entry-content.spec.ts
+++ b/spec/utils/generate-workers-entry-content.spec.ts
@@ -1,27 +1,37 @@
 import { describe, it, expect } from 'vitest'
 import { generateWorkersEntryContent } from '../../src/utils/generate-workers-entry-content'
+import { generateRedisConnectionExpr } from '../../src/utils/generate-redis-connection-expr'
 
 describe('generate-workers-entry-content', () => {
-  it('matches snapshot for single worker and undefined redis', () => {
+  it('matches snapshot for single worker and empty redis config', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
+      redisExpr,
     )
     expect(content).toMatchSnapshot()
   })
 
-  it('matches snapshot for multiple workers and redis url', () => {
+  it('matches snapshot for multiple workers and redis config', () => {
+    const redisExpr = generateRedisConnectionExpr(JSON.stringify({ host: 'localhost', port: 6379 }))
     const content = generateWorkersEntryContent(
       ['/app/server/workers/basic.ts', '/app/server/workers/hello.ts'],
-      'new (await import("ioredis")).default("redis://localhost:6379")',
+      redisExpr,
     )
     expect(content).toMatchSnapshot()
+  })
+
+  it('generates entry that imports resolveRedisConnection', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
+    const content = generateWorkersEntryContent(['/path/to/worker.mjs'], redisExpr)
+    expect(content).toContain('import { resolveRedisConnection } from \'#resolve-redis\'')
   })
 
   it('generates entry that parses --workers flag from process.argv', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
+      redisExpr,
     )
     expect(content).toContain('process.argv.find(a => typeof a === \'string\' && a.startsWith(\'--workers=\'))')
     expect(content).toContain('workersArg.split(\'=\')[1].split(\',\').map(s => s.trim()).filter(Boolean)')
@@ -30,26 +40,29 @@ describe('generate-workers-entry-content', () => {
   })
 
   it('generates entry that filters workers by name when --workers is set', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
+      redisExpr,
     )
     expect(content).toContain('selectedWorkers.includes(w.name)')
     expect(content).toContain('api.workers.filter(w => w && selectedWorkers.includes(w.name))')
   })
 
   it('generates entry that runs all workers when --workers is not set', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
+      redisExpr,
     )
     expect(content).toContain('(Array.isArray(api.workers) ? api.workers : [])')
   })
 
   it('generates entry that returns stop closing only workersToRun', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
+      redisExpr,
     )
     expect(content).toContain('workersToRun.map(w => w.close())')
     expect(content).toContain('closeRunningWorkers')
@@ -57,9 +70,10 @@ describe('generate-workers-entry-content', () => {
   })
 
   it('generates entry that warns and exits when no workers match --workers filter', () => {
+    const redisExpr = generateRedisConnectionExpr('{}')
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
+      redisExpr,
     )
     expect(content).toContain('selectedWorkers && workersToRun.length === 0')
     expect(content).toContain('logger.warn')

--- a/src/runtime/server/utils/resolve-redis-connection.ts
+++ b/src/runtime/server/utils/resolve-redis-connection.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolves Redis connection options at runtime.
+ *
+ * Environment variables take precedence over the static config snapshot
+ * captured at build time. Returns an object with all options preserved,
+ * including `url` when applicable, so `setConnection` can pass them
+ * all to the IORedis constructor.
+ */
+export function resolveRedisConnection(
+  staticConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const url = process.env.NUXT_REDIS_URL ?? staticConfig.url
+  return {
+    ...(url ? { url } : {}),
+    host: process.env.NUXT_REDIS_HOST ?? staticConfig.host ?? '127.0.0.1',
+    port: Number(process.env.NUXT_REDIS_PORT ?? staticConfig.port ?? 6379),
+    password: process.env.NUXT_REDIS_PASSWORD ?? staticConfig.password ?? '',
+    username: process.env.NUXT_REDIS_USERNAME ?? staticConfig.username ?? undefined,
+    db: Number(process.env.NUXT_REDIS_DB ?? staticConfig.db ?? 0),
+    lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT
+      ? process.env.NUXT_REDIS_LAZY_CONNECT === 'true'
+      : (staticConfig.lazyConnect as boolean | undefined),
+    connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT
+      ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT)
+      : (staticConfig.connectTimeout as number | undefined),
+  }
+}

--- a/src/runtime/server/utils/resolve-redis-connection.ts
+++ b/src/runtime/server/utils/resolve-redis-connection.ts
@@ -2,26 +2,71 @@
  * Resolves Redis connection options at runtime.
  *
  * Environment variables take precedence over the static config snapshot
- * captured at build time. Returns an object with all options preserved,
- * including `url` when applicable, so `setConnection` can pass them
- * all to the IORedis constructor.
+ * captured at build time. The static config is shallow-merged first so
+ * any extra IORedis keys (tls, sentinels, enableReadyCheck, etc.) are
+ * preserved even though we don't have dedicated env-var overrides for them.
+ *
+ * Numeric env values are validated: if parsing yields NaN the static value
+ * (or a safe default) is used instead.
  */
+
+/** Parse a numeric env value, returning `fallback` when the result is NaN. */
+function safeNumber(envValue: string | undefined, fallback: number): number {
+  if (envValue === undefined || envValue === '') return fallback
+  const n = Number(envValue)
+  return Number.isNaN(n) ? fallback : n
+}
+
+/**
+ * Parse a boolean-ish env string.
+ * Returns `true` for `'true'`, `false` for `'false'`, and `undefined`
+ * for anything else (so the static config value is kept).
+ */
+function safeBool(envValue: string | undefined): boolean | undefined {
+  if (envValue === 'true') return true
+  if (envValue === 'false') return false
+  return undefined
+}
+
 export function resolveRedisConnection(
   staticConfig: Record<string, unknown>,
 ): Record<string, unknown> {
-  const url = process.env.NUXT_REDIS_URL ?? staticConfig.url
-  return {
-    ...(url ? { url } : {}),
-    host: process.env.NUXT_REDIS_HOST ?? staticConfig.host ?? '127.0.0.1',
-    port: Number(process.env.NUXT_REDIS_PORT ?? staticConfig.port ?? 6379),
-    password: process.env.NUXT_REDIS_PASSWORD ?? staticConfig.password ?? '',
-    username: process.env.NUXT_REDIS_USERNAME ?? staticConfig.username ?? undefined,
-    db: Number(process.env.NUXT_REDIS_DB ?? staticConfig.db ?? 0),
-    lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT
-      ? process.env.NUXT_REDIS_LAZY_CONNECT === 'true'
-      : (staticConfig.lazyConnect as boolean | undefined),
-    connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT
-      ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT)
-      : (staticConfig.connectTimeout as number | undefined),
+  // 1. Shallow-merge staticConfig so extra keys survive.
+  const merged: Record<string, unknown> = { ...staticConfig }
+
+  // 2. Apply env overrides for known keys only.
+  const url = process.env.NUXT_REDIS_URL ?? merged.url
+  if (url) {
+    merged.url = url
   }
+  else {
+    // Only delete if it was never set — avoids leaving a stale key.
+    delete merged.url
+  }
+
+  merged.host = process.env.NUXT_REDIS_HOST ?? merged.host ?? '127.0.0.1'
+  merged.port = safeNumber(process.env.NUXT_REDIS_PORT, Number(merged.port ?? 6379))
+  merged.password = process.env.NUXT_REDIS_PASSWORD ?? merged.password ?? ''
+  merged.username = process.env.NUXT_REDIS_USERNAME ?? merged.username ?? undefined
+  merged.db = safeNumber(process.env.NUXT_REDIS_DB, Number(merged.db ?? 0))
+
+  const envLazy = safeBool(process.env.NUXT_REDIS_LAZY_CONNECT)
+  if (envLazy !== undefined) {
+    merged.lazyConnect = envLazy
+  }
+  else if (!('lazyConnect' in merged)) {
+    merged.lazyConnect = undefined
+  }
+
+  if (process.env.NUXT_REDIS_CONNECT_TIMEOUT) {
+    merged.connectTimeout = safeNumber(
+      process.env.NUXT_REDIS_CONNECT_TIMEOUT,
+      (merged.connectTimeout as number | undefined) ?? undefined as unknown as number,
+    )
+  }
+  else if (!('connectTimeout' in merged)) {
+    merged.connectTimeout = undefined
+  }
+
+  return merged
 }

--- a/src/utils/generate-redis-connection-expr.ts
+++ b/src/utils/generate-redis-connection-expr.ts
@@ -1,16 +1,19 @@
+/**
+ * Returns a JavaScript code snippet that calls `resolveRedisConnection`
+ * at runtime with the static config as a fallback.
+ *
+ * The generated code imports the runtime helper and passes the build-time
+ * snapshot so env vars can override individual fields.
+ *
+ * @param staticRedis - JSON-stringified Redis options from nuxt.config (build-time snapshot)
+ */
 export function generateRedisConnectionExpr(staticRedis: string): string {
-  return `(() => {
-  const s = ${staticRedis};
-  const url = process.env.NUXT_REDIS_URL ?? s.url;
-  if (url) return url;
-  return {
-    host: process.env.NUXT_REDIS_HOST ?? s.host ?? '127.0.0.1',
-    port: Number(process.env.NUXT_REDIS_PORT ?? s.port ?? 6379),
-    password: process.env.NUXT_REDIS_PASSWORD ?? s.password ?? '',
-    username: process.env.NUXT_REDIS_USERNAME ?? s.username ?? undefined,
-    db: Number(process.env.NUXT_REDIS_DB ?? s.db ?? 0),
-    lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT ? process.env.NUXT_REDIS_LAZY_CONNECT === 'true' : s.lazyConnect,
-    connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT) : s.connectTimeout,
-  };
-})()`
+  return `resolveRedisConnection(${staticRedis})`
+}
+
+/**
+ * Returns the import statement needed alongside the expression.
+ */
+export function getRedisConnectionImport(alias: string): string {
+  return `import { resolveRedisConnection } from '${alias}'`
 }

--- a/src/utils/generate-redis-connection-expr.ts
+++ b/src/utils/generate-redis-connection-expr.ts
@@ -1,0 +1,16 @@
+export function generateRedisConnectionExpr(staticRedis: string): string {
+  return `(() => {
+  const s = ${staticRedis};
+  const url = process.env.NUXT_REDIS_URL ?? s.url;
+  if (url) return url;
+  return {
+    host: process.env.NUXT_REDIS_HOST ?? s.host ?? '127.0.0.1',
+    port: Number(process.env.NUXT_REDIS_PORT ?? s.port ?? 6379),
+    password: process.env.NUXT_REDIS_PASSWORD ?? s.password ?? '',
+    username: process.env.NUXT_REDIS_USERNAME ?? s.username ?? undefined,
+    db: Number(process.env.NUXT_REDIS_DB ?? s.db ?? 0),
+    lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT ? process.env.NUXT_REDIS_LAZY_CONNECT === 'true' : s.lazyConnect,
+    connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT) : s.connectTimeout,
+  };
+})()`
+}

--- a/src/utils/generate-workers-entry-content.ts
+++ b/src/utils/generate-workers-entry-content.ts
@@ -1,15 +1,19 @@
-export function generateWorkersEntryContent(workerFiles: string[], redisInline: string): string {
+import { getRedisConnectionImport } from './generate-redis-connection-expr'
+
+export function generateWorkersEntryContent(workerFiles: string[], redisConnectionExpr: string): string {
   const toImportArray = workerFiles.map(id => `() => import(${JSON.stringify(id)})`).join(',\n    ')
+  const redisImport = getRedisConnectionImport('#resolve-redis')
   return `
 import { fileURLToPath } from 'node:url'
 import { resolve as resolvePath } from 'node:path'
 import { consola } from 'consola'
 import { $workers } from '#processor-utils'
+${redisImport}
 
 // Initialize connection as early as possible so any imports that register
 // workers/queues have a valid connection available.
 const api = $workers()
-api.setConnection(${redisInline})
+api.setConnection(${redisConnectionExpr})
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)


### PR DESCRIPTION
## Summary

Adds support for reading env vars post build

## Changes

- Adds a method to read runtime env or use statically set vars

## How to Test

1. Build a project with no redis vars
2. Verify once deployed it reads runtime vars

## Screenshots (optional)

N/A

## Linked Issues

#30 

## Checklist

- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated docs (README/docs) if needed
- [x] `npm run lint` and `npm test` pass
- [x] No breaking changes, or I documented them above