### PR TITLE
env updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ export default defineNuxtConfig({
     redis: {
       // Prefer a single URL if available (takes precedence over other fields)
       // e.g. redis://user:pass@host:6379/0
-      url: process.env.NUXT_REDIS_URL,
-      host: process.env.NUXT_REDIS_HOST ?? '127.0.0.1',
-      port: Number(process.env.NUXT_REDIS_PORT ?? 6379),
-      password: process.env.NUXT_REDIS_PASSWORD ?? '',
-      username: process.env.NUXT_REDIS_USERNAME,
-      db: Number(process.env.NUXT_REDIS_DB ?? 0),
+      url: process.env.REDIS_URL,
+      host: process.env.REDIS_HOST ?? '127.0.0.1',
+      port: Number(process.env.REDIS_PORT ?? 6379),
+      password: process.env.REDIS_PASSWORD ?? '',
+      username: process.env.REDIS_USERNAME,
+      db: Number(process.env.REDIS_DB ?? 0),
       // Optional connection behavior
       // Delay connecting until first Redis command (useful to avoid build-time connects)
-      lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT
-        ? process.env.NUXT_REDIS_LAZY_CONNECT === 'true'
+      lazyConnect: process.env.REDIS_LAZY_CONNECT
+        ? process.env.REDIS_LAZY_CONNECT === 'true'
         : undefined,
       // Milliseconds to wait before giving up when establishing the connection
-      connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT
-        ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT)
+      connectTimeout: process.env.REDIS_CONNECT_TIMEOUT
+        ? Number(process.env.REDIS_CONNECT_TIMEOUT)
         : undefined,
     },
   },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,20 +20,20 @@ export default defineNuxtConfig({
     redis: {
       // Prefer a single URL if available (takes precedence over other fields)
       // e.g. redis://user:pass@host:6379/0
-      url: process.env.NUXT_REDIS_URL,
-      host: process.env.NUXT_REDIS_HOST ?? '127.0.0.1',
-      port: Number(process.env.NUXT_REDIS_PORT ?? 6379),
-      password: process.env.NUXT_REDIS_PASSWORD ?? '',
-      username: process.env.NUXT_REDIS_USERNAME,
-      db: Number(process.env.NUXT_REDIS_DB ?? 0),
+      url: process.env.REDIS_URL,
+      host: process.env.REDIS_HOST ?? '127.0.0.1',
+      port: Number(process.env.REDIS_PORT ?? 6379),
+      password: process.env.REDIS_PASSWORD ?? '',
+      username: process.env.REDIS_USERNAME,
+      db: Number(process.env.REDIS_DB ?? 0),
       // Optional connection behavior
       // Delay connecting until first Redis command (useful to avoid build-time connects)
-      lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT
-        ? process.env.NUXT_REDIS_LAZY_CONNECT === 'true'
+      lazyConnect: process.env.REDIS_LAZY_CONNECT
+        ? process.env.REDIS_LAZY_CONNECT === 'true'
         : undefined,
       // Milliseconds to wait before giving up when establishing the connection
-      connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT
-        ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT)
+      connectTimeout: process.env.REDIS_CONNECT_TIMEOUT
+        ? Number(process.env.REDIS_CONNECT_TIMEOUT)
         : undefined,
     },
   },

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=build /app/playground/.output ./.output
 COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/playground/node_modules ./node_modules
 
-CMD ["node", ".output/server/index.mjs"]
+CMD ["node", ".output/server/workers/index.mjs"]

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY playground/package*.json ./playground/
+RUN cd playground && npm install
+
+COPY . .
+RUN npm run dev:prepare && npm run dev:build
+
+FROM node:22-alpine
+
+WORKDIR /app/playground
+ENV NODE_ENV=production
+
+COPY --from=build /app/playground/.output ./.output
+COPY --from=build /app/node_modules /app/node_modules
+COPY --from=build /app/playground/node_modules ./node_modules
+
+CMD ["node", ".output/server/index.mjs"]

--- a/playground/Dockerfile.dockerignore
+++ b/playground/Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+.git
+.cursor
+.nuxt
+.output
+coverage
+dist
+node_modules
+playground/.nuxt
+playground/.output
+playground/node_modules

--- a/playground/compose.runtime.yml
+++ b/playground/compose.runtime.yml
@@ -1,0 +1,23 @@
+services:
+  redis-runtime:
+    image: redis:7-alpine
+    command: ["redis-server", "--port", "6381"]
+
+  app:
+    build:
+      context: ..
+      dockerfile: playground/Dockerfile
+    environment:
+      NUXT_REDIS_URL: redis://redis-runtime:6381/0
+    depends_on:
+      - redis-runtime
+
+  workers:
+    build:
+      context: ..
+      dockerfile: playground/Dockerfile
+    command: ["node", ".output/server/workers/index.mjs"]
+    environment:
+      NUXT_REDIS_URL: redis://redis-runtime:6381/0
+    depends_on:
+      - redis-runtime

--- a/playground/compose.runtime.yml
+++ b/playground/compose.runtime.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: playground/Dockerfile
     command: ["node", ".output/server/index.mjs"]
     environment:
-      NUXT_REDIS_URL: redis://redis-runtime:6381/0
+      REDIS_URL: redis://redis-runtime:6381/0
     depends_on:
       - redis-runtime
 
@@ -18,6 +18,6 @@ services:
       context: ..
       dockerfile: playground/Dockerfile
     environment:
-      NUXT_REDIS_URL: redis://redis-runtime:6381/0
+      REDIS_URL: redis://redis-runtime:6381/0
     depends_on:
       - redis-runtime

--- a/playground/compose.runtime.yml
+++ b/playground/compose.runtime.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: ..
       dockerfile: playground/Dockerfile
+    command: ["node", ".output/server/index.mjs"]
     environment:
       NUXT_REDIS_URL: redis://redis-runtime:6381/0
     depends_on:
@@ -16,7 +17,6 @@ services:
     build:
       context: ..
       dockerfile: playground/Dockerfile
-    command: ["node", ".output/server/workers/index.mjs"]
     environment:
       NUXT_REDIS_URL: redis://redis-runtime:6381/0
     depends_on:

--- a/playground/server/workers/basic.ts
+++ b/playground/server/workers/basic.ts
@@ -1,8 +1,12 @@
 import { defineWorker } from '#processor'
+import { consola } from 'consola'
+
+const logger = consola.withTag('basic-worker')
 
 export default defineWorker({
   name: 'basic',
   async processor(job) {
+    logger.info('processed basic job', job.id)
     return { ok: true, received: job.data }
   },
 })

--- a/playground/server/workers/index.ts
+++ b/playground/server/workers/index.ts
@@ -1,13 +1,17 @@
 import { defineWorker } from '#processor'
+import { consola } from 'consola'
 
 type HelloName = 'hello'
 type HelloData = { message: string, ts: number }
 type HelloResult = { echoed: string, processedAt: number }
 
+const logger = consola.withTag('hello-worker')
+
 export default defineWorker<HelloName, HelloData, HelloResult>({
   name: 'hello',
   async processor(job) {
     const { message, ts } = job.data
+    logger.info('processed hello job', job.id)
     return { echoed: message, processedAt: ts }
   },
   options: {},

--- a/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
+++ b/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
@@ -5,12 +5,14 @@ exports[`generate-workers-entry-content > matches snapshot for multiple workers 
 import { fileURLToPath } from 'node:url'
 import { resolve as resolvePath } from 'node:path'
 import { consola } from 'consola'
+import { useRuntimeConfig } from '#imports'
 import { $workers } from '#processor-utils'
 
 // Initialize connection as early as possible so any imports that register
 // workers/queues have a valid connection available.
 const api = $workers()
-api.setConnection(new (await import("ioredis")).default("redis://localhost:6379"))
+const { redis } = useRuntimeConfig()
+api.setConnection(redis)
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)
@@ -113,12 +115,14 @@ exports[`generate-workers-entry-content > matches snapshot for single worker and
 import { fileURLToPath } from 'node:url'
 import { resolve as resolvePath } from 'node:path'
 import { consola } from 'consola'
+import { useRuntimeConfig } from '#imports'
 import { $workers } from '#processor-utils'
 
 // Initialize connection as early as possible so any imports that register
 // workers/queues have a valid connection available.
 const api = $workers()
-api.setConnection(undefined)
+const { redis } = useRuntimeConfig()
+api.setConnection(redis)
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)

--- a/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
+++ b/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
@@ -12,7 +12,7 @@ import { $workers } from '#processor-utils'
 // workers/queues have a valid connection available.
 const api = $workers()
 const { redis } = useRuntimeConfig()
-api.setConnection(redis)
+api.setConnection(process.env.REDIS_URL ? { ...redis, url: process.env.REDIS_URL } : redis)
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)
@@ -122,7 +122,7 @@ import { $workers } from '#processor-utils'
 // workers/queues have a valid connection available.
 const api = $workers()
 const { redis } = useRuntimeConfig()
-api.setConnection(redis)
+api.setConnection(process.env.REDIS_URL ? { ...redis, url: process.env.REDIS_URL } : redis)
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)

--- a/spec/utils/generate-workers-entry-content.spec.ts
+++ b/spec/utils/generate-workers-entry-content.spec.ts
@@ -5,7 +5,6 @@ describe('generate-workers-entry-content', () => {
   it('matches snapshot for single worker and undefined redis', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
     )
     expect(content).toMatchSnapshot()
   })
@@ -13,15 +12,23 @@ describe('generate-workers-entry-content', () => {
   it('matches snapshot for multiple workers and redis url', () => {
     const content = generateWorkersEntryContent(
       ['/app/server/workers/basic.ts', '/app/server/workers/hello.ts'],
-      'new (await import("ioredis")).default("redis://localhost:6379")',
     )
     expect(content).toMatchSnapshot()
+  })
+
+  it('generates entry that reads Redis from runtime config', () => {
+    const content = generateWorkersEntryContent(
+      ['/path/to/worker.mjs'],
+    )
+
+    expect(content).toContain('import { useRuntimeConfig } from \'#imports\'')
+    expect(content).toContain('const { redis } = useRuntimeConfig()')
+    expect(content).toContain('api.setConnection(redis)')
   })
 
   it('generates entry that parses --workers flag from process.argv', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
     )
     expect(content).toContain('process.argv.find(a => typeof a === \'string\' && a.startsWith(\'--workers=\'))')
     expect(content).toContain('workersArg.split(\'=\')[1].split(\',\').map(s => s.trim()).filter(Boolean)')
@@ -32,7 +39,6 @@ describe('generate-workers-entry-content', () => {
   it('generates entry that filters workers by name when --workers is set', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
     )
     expect(content).toContain('selectedWorkers.includes(w.name)')
     expect(content).toContain('api.workers.filter(w => w && selectedWorkers.includes(w.name))')
@@ -41,7 +47,6 @@ describe('generate-workers-entry-content', () => {
   it('generates entry that runs all workers when --workers is not set', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
     )
     expect(content).toContain('(Array.isArray(api.workers) ? api.workers : [])')
   })
@@ -49,7 +54,6 @@ describe('generate-workers-entry-content', () => {
   it('generates entry that returns stop closing only workersToRun', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
     )
     expect(content).toContain('workersToRun.map(w => w.close())')
     expect(content).toContain('closeRunningWorkers')
@@ -59,7 +63,6 @@ describe('generate-workers-entry-content', () => {
   it('generates entry that warns and exits when no workers match --workers filter', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
-      'undefined',
     )
     expect(content).toContain('selectedWorkers && workersToRun.length === 0')
     expect(content).toContain('logger.warn')

--- a/spec/utils/generate-workers-entry-content.spec.ts
+++ b/spec/utils/generate-workers-entry-content.spec.ts
@@ -16,14 +16,14 @@ describe('generate-workers-entry-content', () => {
     expect(content).toMatchSnapshot()
   })
 
-  it('generates entry that reads Redis from runtime config', () => {
+  it('generates entry that reads Redis from runtime config and REDIS_URL', () => {
     const content = generateWorkersEntryContent(
       ['/path/to/worker.mjs'],
     )
 
     expect(content).toContain('import { useRuntimeConfig } from \'#imports\'')
     expect(content).toContain('const { redis } = useRuntimeConfig()')
-    expect(content).toContain('api.setConnection(redis)')
+    expect(content).toContain('api.setConnection(process.env.REDIS_URL ? { ...redis, url: process.env.REDIS_URL } : redis)')
   })
 
   it('generates entry that parses --workers flag from process.argv', () => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -55,7 +55,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     export default defineNitroPlugin(() => {
       const { redis } = useRuntimeConfig()
-      $workers().setConnection(redis)
+      $workers().setConnection(process.env.REDIS_URL ? { ...redis, url: process.env.REDIS_URL } : redis)
     })
     `
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -29,14 +29,14 @@ export default defineNuxtModule<ModuleOptions>({
   // Default configuration options of the Nuxt module
   defaults: {
     redis: {
-      host: process.env.NUXT_REDIS_HOST ?? '127.0.0.1',
-      port: Number(process.env.NUXT_REDIS_PORT ?? 6379),
-      password: process.env.NUXT_REDIS_PASSWORD ?? '',
-      username: process.env.NUXT_REDIS_USERNAME ?? undefined, // needs Redis >= 6
-      db: Number(process.env.NUXT_REDIS_DB ?? 0), // Defaults to 0 on ioredis
-      lazyConnect: process.env.NUXT_REDIS_LAZY_CONNECT === 'true' ? true : undefined,
-      connectTimeout: process.env.NUXT_REDIS_CONNECT_TIMEOUT ? Number(process.env.NUXT_REDIS_CONNECT_TIMEOUT) : undefined,
-      url: process.env.NUXT_REDIS_URL ?? undefined,
+      host: process.env.REDIS_HOST ?? '127.0.0.1',
+      port: Number(process.env.REDIS_PORT ?? 6379),
+      password: process.env.REDIS_PASSWORD ?? '',
+      username: process.env.REDIS_USERNAME ?? undefined, // needs Redis >= 6
+      db: Number(process.env.REDIS_DB ?? 0), // Defaults to 0 on ioredis
+      lazyConnect: process.env.REDIS_LAZY_CONNECT === 'true' ? true : undefined,
+      connectTimeout: process.env.REDIS_CONNECT_TIMEOUT ? Number(process.env.REDIS_CONNECT_TIMEOUT) : undefined,
+      url: process.env.REDIS_URL ?? undefined,
     } as ModuleRedisOptions,
     workers: 'server/workers',
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -43,14 +43,19 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(_options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
 
-    const redisInline = JSON.stringify(_options.redis ?? {})
+    const runtimeConfig = nuxt.options.runtimeConfig as typeof nuxt.options.runtimeConfig & { redis?: ModuleRedisOptions }
+    runtimeConfig.redis = {
+      ...(_options.redis ?? {}),
+      ...(runtimeConfig.redis ?? {}),
+    }
 
     const nitroPlugin = `
-    import { defineNitroPlugin } from '#imports'
+    import { defineNitroPlugin, useRuntimeConfig } from '#imports'
     import { $workers } from '#processor-utils'
 
     export default defineNitroPlugin(() => {
-      $workers().setConnection(${redisInline})
+      const { redis } = useRuntimeConfig()
+      $workers().setConnection(redis)
     })
     `
 
@@ -109,7 +114,7 @@ declare module '#bullmq' {
             virtualCode = ''
             return
           }
-          virtualCode = generateWorkersEntryContent(workerFiles, redisInline)
+          virtualCode = generateWorkersEntryContent(workerFiles)
           for (const id of workerFiles) {
             this.addWatchFile(id)
           }

--- a/src/utils/generate-workers-entry-content.ts
+++ b/src/utils/generate-workers-entry-content.ts
@@ -11,7 +11,7 @@ import { $workers } from '#processor-utils'
 // workers/queues have a valid connection available.
 const api = $workers()
 const { redis } = useRuntimeConfig()
-api.setConnection(redis)
+api.setConnection(process.env.REDIS_URL ? { ...redis, url: process.env.REDIS_URL } : redis)
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)

--- a/src/utils/generate-workers-entry-content.ts
+++ b/src/utils/generate-workers-entry-content.ts
@@ -1,15 +1,17 @@
-export function generateWorkersEntryContent(workerFiles: string[], redisInline: string): string {
+export function generateWorkersEntryContent(workerFiles: string[]): string {
   const toImportArray = workerFiles.map(id => `() => import(${JSON.stringify(id)})`).join(',\n    ')
   return `
 import { fileURLToPath } from 'node:url'
 import { resolve as resolvePath } from 'node:path'
 import { consola } from 'consola'
+import { useRuntimeConfig } from '#imports'
 import { $workers } from '#processor-utils'
 
 // Initialize connection as early as possible so any imports that register
 // workers/queues have a valid connection available.
 const api = $workers()
-api.setConnection(${redisInline})
+const { redis } = useRuntimeConfig()
+api.setConnection(redis)
 
 export async function createWorkersApp() {
 // Avoid EPIPE when stdout/stderr are closed by terminal (e.g., Ctrl+C piping)


### PR DESCRIPTION
## Summary

Uses useruntimeconfig for all env vars like I shouldve done from the start

## Changes

- uses use runtime config for workers
- fixes init process for queues

## How to Test

1. use docker image, verify workers run

## Screenshots (optional)

If applicable, add screenshots or recordings.

## Linked Issues

[Closes 49](https://github.com/aidanhibbard/nuxt-processor/issues/49)
[Closes 30](https://github.com/aidanhibbard/nuxt-processor/issues/30)

## Checklist

- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated docs (README/docs) if needed
- [x] `npm run lint` and `npm test` pass
- [x] No breaking changes, or I documented them above