### PR TITLE
feat: implement workers pattern

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### 🚀 Enhancements
+
+- Add `processor.workersPattern` module option to customize the glob used when scanning the workers directory (default unchanged: `**/*.{ts,js,mjs}`).
+
 ### 📖 Documentation
 
 - Replace the Bull Board playground/docs example with Durabull setup guidance.

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,13 +32,32 @@ export default defineNuxtConfig({
 })
 ```
 
+Exclude co-located test files with a custom pattern ([micromatch extglob](https://github.com/micromatch/micromatch#extglob)):
+
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-processor'],
+  processor: {
+    workers: 'server/workers',
+    workersPattern: '**/!(*.test|*.spec).{ts,js,mjs}',
+  },
+})
+```
+
+`workers` is the path to the workers directory (resolved from the project root). Globs belong in `workersPattern`, which is relative to that directory.
+
 ```ts
 interface ModuleOptions {
   /**
-   * Folder scanned for worker files ({ts,js,mjs}).
+   * Path to the workers directory, relative to the project root.
    * @default 'server/workers'
    */
   workers: string
+  /**
+   * Glob pattern relative to `workers`.
+   * @default '**/*.{ts,js,mjs}'
+   */
+  workersPattern?: string
 }
 ```
 

--- a/spec/utils/scan-folder.spec.ts
+++ b/spec/utils/scan-folder.spec.ts
@@ -47,11 +47,42 @@ describe('scan-folder', () => {
     // ignored extension
     writeFileSync(join(absDir, 'ignored.txt'), 'ignore')
 
-    const files = await scanFolder(dir)
+    const files = await scanFolder({ path: dir })
     expect(files.sort()).toEqual([
       join(absDir, 'a.ts'),
       join(absDir, 'b.js'),
       join(absDir, 'nested', 'c.mjs'),
     ].sort())
+  })
+
+  it('uses a custom pattern to limit extensions', async () => {
+    const dir = join('some', 'workers')
+    const absDir = join(tmpDir, dir)
+    mkdirSync(absDir, { recursive: true })
+    writeFileSync(join(absDir, 'a.ts'), 'export {}')
+    writeFileSync(join(absDir, 'b.js'), 'module.exports = {}')
+
+    const files = await scanFolder({ path: dir, pattern: '**/*.ts' })
+    expect(files).toEqual([join(absDir, 'a.ts')])
+  })
+
+  it('supports extglob patterns to exclude spec files', async () => {
+    const dir = join('some', 'workers')
+    const absDir = join(tmpDir, dir)
+    mkdirSync(absDir, { recursive: true })
+    writeFileSync(join(absDir, 'worker.ts'), 'export {}')
+    writeFileSync(join(absDir, 'worker.spec.ts'), 'export {}')
+
+    const files = await scanFolder({ path: dir, pattern: '**/!(*.spec).ts' })
+    expect(files).toEqual([join(absDir, 'worker.ts')])
+  })
+
+  it('warns and returns an empty array when no files match', async () => {
+    const dir = join('empty', 'workers')
+    const absDir = join(tmpDir, dir)
+    mkdirSync(absDir, { recursive: true })
+
+    const files = await scanFolder({ path: dir })
+    expect(files).toEqual([])
   })
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,11 +9,15 @@ import { generateWorkersIndexWrapper } from './utils/generate-workers-index-wrap
 
 export interface ModuleOptions {
   /**
-   * The folder containing the worker files
-   * Scans for {ts,js,mjs}
+   * Path to the directory containing worker files, relative to the project root.
    * @default 'server/workers'
    */
   workers: string
+  /**
+   * Glob pattern relative to `workers`.
+   * @default '**/*.{ts,js,mjs}'
+   */
+  workersPattern?: string
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -25,6 +29,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     workers: 'server/workers',
+    workersPattern: '**/*.{ts,js,mjs}',
   },
   async setup(_options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
@@ -78,7 +83,10 @@ declare module '@nuxt/schema' {
       return {
         name: 'nuxt-processor-emit',
         async buildStart() {
-          const workerFiles = await scanFolder(_options.workers)
+          const workerFiles = await scanFolder({
+            path: _options.workers,
+            pattern: _options.workersPattern,
+          })
           if (workerFiles.length === 0) {
             virtualCode = ''
             return

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,7 @@ export interface ModuleOptions {
   workers: string
   /**
    * Glob pattern relative to `workers`.
-   * @default '**/*.{ts,js,mjs}'
+   * @default '**\/*.{ts,js,mjs}'
    */
   workersPattern?: string
 }

--- a/src/utils/scan-folder.ts
+++ b/src/utils/scan-folder.ts
@@ -5,7 +5,13 @@ import { logger } from './logger'
 // Credit for this code to
 // https://github.com/genu/nuxt-concierge/blob/master/src/helplers/scan-folder.ts
 
-export default async (path: string): Promise<string[]> => {
+export interface ScanFolderOptions {
+  /** Path to the workers directory, relative to the project root. */
+  path: string
+  pattern?: string
+}
+
+export default async ({ path, pattern = '**/*.{ts,js,mjs}' }: ScanFolderOptions): Promise<string[]> => {
   const nuxt = useNuxt()
   const { resolve } = createResolver(import.meta.url)
   // https://github.com/genu/nuxt-concierge/issues/8
@@ -13,7 +19,7 @@ export default async (path: string): Promise<string[]> => {
 
   const files: string[] = []
 
-  const updatedFiles = await fg('**/*.{ts,js,mjs}', {
+  const updatedFiles = await fg(pattern, {
     cwd: resolvedPath,
     absolute: true,
     onlyFiles: true,


### PR DESCRIPTION
## Summary

Allows for developers to pass their own pattern for scanning worker files.

## Changes

- Implements an optional pattern for scanning workers directories.

## How to Test

1. Boot your app with worker files using a pattern and a mix of file types
2. Verify only your selected files are scanned

## Screenshots (optional)

N/A

## Linked Issues

Closes #60

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated docs (README/docs) if needed
- [x] `npm run ci` passes (or `npm run lint` and `npm test` at minimum)
- [x] No breaking changes, or I documented them above