### PR TITLE
feat: scan workers using cli

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,14 @@
 
 ### 🚀 Enhancements
 
+- Add `workers list --json` CLI command for machine-readable worker discovery.
+- Fail builds and workers startup when duplicate worker names are discovered.
 - Add `defineFlowProducer()` helper with shared Redis config, registry shutdown via `stopAll()`, and native BullMQ `add()` / `addBulk()` surface.
 - Add `processor.workersPattern` module option to customize the glob used when scanning the workers directory (default unchanged: `**/*.{ts,js,mjs}`).
 
 ### 📖 Documentation
 
+- Document `workers list --json` and duplicate worker name errors in `docs/api.md`.
 - Add [Define Flow Producer](/define-flow-producer) guide covering flows, `getChildrenValues()`, `waiting-children`, failed-child options, and cleanup.
 - Replace the Bull Board playground/docs example with Durabull setup guidance.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -348,11 +348,19 @@ Build output includes `.output/server/workers/index.mjs`, which loads `server/wo
 ```bash
 npx nuxt-processor dev
 npx nuxt-processor dev --workers=basic,hello
+npx nuxt-processor workers list
+npx nuxt-processor workers list --json
+npx nuxt-processor workers list --json --workers=hello
 ```
 
-| Argument | Description |
+| Command / argument | Description |
 | --- | --- |
-| `--workers=name1,name2` | Run only workers with matching queue names (default: all) |
+| `dev` | Run workers with HMR from `.nuxt/dev/workers/index.mjs` |
+| `workers list` | List workers discovered from source files (no Nuxt dev server required) |
+| `workers list --json` | Output the worker manifest as JSON |
+| `--workers=name1,name2` | On `dev`, run only matching workers. On `workers list`, filter the manifest and set `selectedWorkers` |
+
+Duplicate worker names fail the Nitro build and workers process startup.
 
 Equivalent direct invocation:
 
@@ -360,6 +368,40 @@ Equivalent direct invocation:
 node .output/server/workers/index.mjs
 node .output/server/workers/index.mjs --workers=basic,hello
 ```
+
+### Worker manifest
+
+`workers list --json` prints a manifest with this shape:
+
+```json
+{
+  "version": "2.1.0",
+  "workersPath": "server/workers",
+  "workersPattern": "**/*.{ts,js,mjs}",
+  "shutdown": { "timeoutMs": 25000 },
+  "selectedWorkers": null,
+  "workers": [
+    {
+      "name": "basic",
+      "source": "server/workers/basic.ts",
+      "options": {
+        "concurrency": 2,
+        "limiter": { "max": 10, "duration": 1000 }
+      },
+      "effective": {
+        "concurrency": 2,
+        "autorun": false,
+        "lockDuration": 30000,
+        "stalledInterval": 30000,
+        "maxStalledCount": 1,
+        "limiter": { "max": 10, "duration": 1000 }
+      }
+    }
+  ]
+}
+```
+
+`shutdown` is omitted when `processor.shutdown.timeoutMs` is not set. `effective` merges user `options` with nuxt-processor overrides (`autorun: false`) and BullMQ defaults. `selectedWorkers` is `null` unless `--workers=` is passed to `workers list`.
 
 ### `createWorkersApp`
 

--- a/spec/cli.spec.ts
+++ b/spec/cli.spec.ts
@@ -282,7 +282,7 @@ export default defineWorker({ name: 'hello', processor: async () => {} })
     const { main } = await importCli()
     await main({ rawArgs: ['workers', 'list', tmpDir, '--json'] })
 
-    const output = stdoutSpy.mock.calls.map(call => String(call[0])).join('')
+    const output = stdoutSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('')
     const manifest = JSON.parse(output) as { workers: Array<{ name: string }>, selectedWorkers: string[] | null }
     expect(manifest.workers.map(worker => worker.name).sort()).toEqual(['basic', 'hello'])
     expect(manifest.selectedWorkers).toBeNull()
@@ -301,7 +301,7 @@ export default defineWorker({ name: 'hello', processor: async () => {} })
     const { main } = await importCli()
     await main({ rawArgs: ['workers', 'list', tmpDir, '--json', '--workers', 'hello'] })
 
-    const output = stdoutSpy.mock.calls.map(call => String(call[0])).join('')
+    const output = stdoutSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('')
     const manifest = JSON.parse(output) as { workers: Array<{ name: string }>, selectedWorkers: string[] | null }
     expect(manifest.selectedWorkers).toEqual(['hello'])
     expect(manifest.workers.map(worker => worker.name)).toEqual(['hello'])

--- a/spec/cli.spec.ts
+++ b/spec/cli.spec.ts
@@ -6,6 +6,19 @@ import os from 'node:os'
 // Mock ensure-nuxt-project to avoid loading real Nuxt configs
 vi.mock('../src/utils/ensure-nuxt-project', () => ({ default: vi.fn(async () => {}) }))
 
+vi.mock('@nuxt/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nuxt/kit')>()
+  return {
+    ...actual,
+    loadNuxtConfig: vi.fn(async () => ({
+      processor: {
+        workers: 'server/workers',
+        workersPattern: '**/*.ts',
+      },
+    })),
+  }
+})
+
 // Mock readline to control user input for prompts
 let promptAnswer = 'n'
 vi.mock('node:readline/promises', () => {
@@ -226,5 +239,71 @@ describe('CLI dev command', () => {
     const spawnArgs = lastSpawnArgs as [string, string[], Record<string, unknown>]
     const nodeArgs = spawnArgs[1]
     expect(nodeArgs).toContain('--workers=basic,hello')
+  })
+})
+
+describe('CLI workers list command', () => {
+  let tmpDir: string
+  let stdoutSpy: ReturnType<typeof vi.spyOn>
+  let exitSpy: { mockRestore: () => void }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'nuxt-processor-cli-workers-'))
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ name: 'app', version: '0.0.0', scripts: {} }, null, 2))
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    exitSpy = (vi.spyOn(process as unknown as { exit: (code?: number | null) => never }, 'exit')
+      .mockImplementation(((code?: number | null) => {
+        throw new Error('process.exit(' + (code ?? 0) + ')')
+      }) as unknown as (code?: number | null) => never)) as unknown as { mockRestore: () => void }
+  })
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+    catch {
+      // ignore cleanup error
+    }
+    stdoutSpy.mockRestore()
+    exitSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  it('prints JSON manifest with workers list --json', async () => {
+    const workersDir = join(tmpDir, 'server', 'workers')
+    mkdirSync(workersDir, { recursive: true })
+    writeFileSync(join(workersDir, 'basic.ts'), `
+export default defineWorker({ name: 'basic', processor: async () => {} })
+`)
+    writeFileSync(join(workersDir, 'hello.ts'), `
+export default defineWorker({ name: 'hello', processor: async () => {} })
+`)
+
+    const { main } = await importCli()
+    await main({ rawArgs: ['workers', 'list', tmpDir, '--json'] })
+
+    const output = stdoutSpy.mock.calls.map(call => String(call[0])).join('')
+    const manifest = JSON.parse(output) as { workers: Array<{ name: string }>, selectedWorkers: string[] | null }
+    expect(manifest.workers.map(worker => worker.name).sort()).toEqual(['basic', 'hello'])
+    expect(manifest.selectedWorkers).toBeNull()
+  })
+
+  it('filters manifest when --workers is provided', async () => {
+    const workersDir = join(tmpDir, 'server', 'workers')
+    mkdirSync(workersDir, { recursive: true })
+    writeFileSync(join(workersDir, 'basic.ts'), `
+export default defineWorker({ name: 'basic', processor: async () => {} })
+`)
+    writeFileSync(join(workersDir, 'hello.ts'), `
+export default defineWorker({ name: 'hello', processor: async () => {} })
+`)
+
+    const { main } = await importCli()
+    await main({ rawArgs: ['workers', 'list', tmpDir, '--json', '--workers', 'hello'] })
+
+    const output = stdoutSpy.mock.calls.map(call => String(call[0])).join('')
+    const manifest = JSON.parse(output) as { workers: Array<{ name: string }>, selectedWorkers: string[] | null }
+    expect(manifest.selectedWorkers).toEqual(['hello'])
+    expect(manifest.workers.map(worker => worker.name)).toEqual(['hello'])
   })
 })

--- a/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
+++ b/spec/utils/__snapshots__/generate-workers-entry-content.spec.ts.snap
@@ -21,8 +21,23 @@ const modules = [
 () => import("/app/server/workers/basic.ts"),
     () => import("/app/server/workers/hello.ts")
 ]
+const logger = consola.create({}).withTag('nuxt-processor')
 for (const loader of modules) {
 await loader()
+}
+const registeredWorkers = Array.isArray(api.workers) ? api.workers : []
+const workerNameCounts = registeredWorkers.reduce((counts, worker) => {
+  if (worker?.name) {
+    counts.set(worker.name, (counts.get(worker.name) ?? 0) + 1)
+  }
+  return counts
+}, new Map())
+const duplicateWorkerNames = [...workerNameCounts.entries()]
+  .filter(([, count]) => count > 1)
+  .map(([name]) => name)
+if (duplicateWorkerNames.length > 0) {
+  logger.error('duplicate worker names found: ' + duplicateWorkerNames.join(', '))
+  process.exit(1)
 }
 // Parse --workers flag (e.g. --workers=basic,hello)
 const workersArg = process.argv.find(a => typeof a === 'string' && a.startsWith('--workers='))
@@ -32,7 +47,6 @@ const selectedWorkers = workersArg
 const workersToRun = selectedWorkers
   ? (Array.isArray(api.workers) ? api.workers.filter(w => w && selectedWorkers.includes(w.name)) : [])
   : (Array.isArray(api.workers) ? api.workers : [])
-const logger = consola.create({}).withTag('nuxt-processor')
 if (selectedWorkers && workersToRun.length === 0) {
   const available = (Array.isArray(api.workers) ? api.workers.map(w => w && w.name).filter(Boolean) : [])
   logger.warn('No workers matched --workers=' + selectedWorkers.join(',') + (available.length ? '. Available: ' + available.join(', ') : '.'))
@@ -86,8 +100,23 @@ try { process.stderr?.on?.('error', handleStreamError) } catch (err) { console.w
 const modules = [
 () => import("/path/to/worker.mjs")
 ]
+const logger = consola.create({}).withTag('nuxt-processor')
 for (const loader of modules) {
 await loader()
+}
+const registeredWorkers = Array.isArray(api.workers) ? api.workers : []
+const workerNameCounts = registeredWorkers.reduce((counts, worker) => {
+  if (worker?.name) {
+    counts.set(worker.name, (counts.get(worker.name) ?? 0) + 1)
+  }
+  return counts
+}, new Map())
+const duplicateWorkerNames = [...workerNameCounts.entries()]
+  .filter(([, count]) => count > 1)
+  .map(([name]) => name)
+if (duplicateWorkerNames.length > 0) {
+  logger.error('duplicate worker names found: ' + duplicateWorkerNames.join(', '))
+  process.exit(1)
 }
 // Parse --workers flag (e.g. --workers=basic,hello)
 const workersArg = process.argv.find(a => typeof a === 'string' && a.startsWith('--workers='))
@@ -97,7 +126,6 @@ const selectedWorkers = workersArg
 const workersToRun = selectedWorkers
   ? (Array.isArray(api.workers) ? api.workers.filter(w => w && selectedWorkers.includes(w.name)) : [])
   : (Array.isArray(api.workers) ? api.workers : [])
-const logger = consola.create({}).withTag('nuxt-processor')
 if (selectedWorkers && workersToRun.length === 0) {
   const available = (Array.isArray(api.workers) ? api.workers.map(w => w && w.name).filter(Boolean) : [])
   logger.warn('No workers matched --workers=' + selectedWorkers.join(',') + (available.length ? '. Available: ' + available.join(', ') : '.'))

--- a/spec/utils/build-worker-manifest.spec.ts
+++ b/spec/utils/build-worker-manifest.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
+import os from 'node:os'
+import {
+  assertNoDuplicateWorkerNames,
+  buildEffectiveWorkerOptions,
+  buildWorkerManifest,
+  DuplicateWorkerNameError,
+} from '../../src/utils/build-worker-manifest'
+
+describe('build-worker-manifest', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'build-worker-manifest-'))
+  })
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+    catch {
+      // ignore cleanup error
+    }
+  })
+
+  it('builds effective defaults for unset options', () => {
+    expect(buildEffectiveWorkerOptions({})).toEqual({
+      concurrency: 1,
+      autorun: false,
+      lockDuration: 30_000,
+      stalledInterval: 30_000,
+      maxStalledCount: 1,
+    })
+  })
+
+  it('throws on duplicate worker names', () => {
+    expect(() => assertNoDuplicateWorkerNames([
+      { name: 'basic', source: 'server/workers/a.ts' },
+      { name: 'basic', source: 'server/workers/b.ts' },
+    ])).toThrow(DuplicateWorkerNameError)
+  })
+
+  it('builds a manifest from worker files', async () => {
+    const workersDir = join(tmpDir, 'server', 'workers')
+    mkdirSync(workersDir, { recursive: true })
+    writeFileSync(join(workersDir, 'basic.ts'), `
+export default defineWorker({
+  name: 'basic',
+  processor: async () => {},
+  options: { concurrency: 3 },
+})
+`)
+    writeFileSync(join(workersDir, 'hello.ts'), `
+export default defineWorker({
+  name: 'hello',
+  processor: async () => {},
+})
+`)
+
+    const manifest = await buildWorkerManifest({
+      rootDir: tmpDir,
+      processorOptions: {
+        workers: 'server/workers',
+        workersPattern: '**/*.ts',
+      },
+    })
+
+    expect(manifest.workers).toHaveLength(2)
+    expect(manifest.workers.map(worker => worker.name).sort()).toEqual(['basic', 'hello'])
+    expect(manifest.workers.find(worker => worker.name === 'basic')?.effective.concurrency).toBe(3)
+    expect(manifest.selectedWorkers).toBeNull()
+  })
+
+  it('filters workers when selectedWorkers is provided', async () => {
+    const workersDir = join(tmpDir, 'server', 'workers')
+    mkdirSync(workersDir, { recursive: true })
+    writeFileSync(join(workersDir, 'basic.ts'), `
+export default defineWorker({ name: 'basic', processor: async () => {} })
+`)
+    writeFileSync(join(workersDir, 'hello.ts'), `
+export default defineWorker({ name: 'hello', processor: async () => {} })
+`)
+
+    const manifest = await buildWorkerManifest({
+      rootDir: tmpDir,
+      processorOptions: {
+        workers: 'server/workers',
+      },
+      selectedWorkers: ['hello'],
+    })
+
+    expect(manifest.selectedWorkers).toEqual(['hello'])
+    expect(manifest.workers.map(worker => worker.name)).toEqual(['hello'])
+  })
+})

--- a/spec/utils/generate-workers-entry-content.spec.ts
+++ b/spec/utils/generate-workers-entry-content.spec.ts
@@ -69,4 +69,13 @@ describe('generate-workers-entry-content', () => {
     expect(content).toContain('Available:')
     expect(content).toContain('process.exit(1)')
   })
+
+  it('generates entry that exits when duplicate worker names are registered', () => {
+    const content = generateWorkersEntryContent(
+      ['/path/to/worker.mjs'],
+    )
+    expect(content).toContain('duplicate worker names found')
+    expect(content).toContain('duplicateWorkerNames.length > 0')
+    expect(content).toContain('process.exit(1)')
+  })
 })

--- a/spec/utils/parse-worker-definition.spec.ts
+++ b/spec/utils/parse-worker-definition.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { parseWorkerDefinition } from '../../src/utils/parse-worker-definition'
+
+describe('parse-worker-definition', () => {
+  it('parses a basic defineWorker call', () => {
+    const source = `
+import { defineWorker } from '#processor'
+
+export default defineWorker({
+  name: 'basic',
+  async processor(job) {
+    return { ok: true }
+  },
+})
+`
+
+    expect(parseWorkerDefinition(source)).toEqual({
+      name: 'basic',
+      options: {},
+    })
+  })
+
+  it('parses defineWorker with generics and options', () => {
+    const source = `
+export default defineWorker<HelloName, HelloData, HelloResult>({
+  name: 'hello',
+  async processor(job) {},
+  options: {
+    concurrency: 2,
+    lockDuration: 60_000,
+    limiter: { max: 10, duration: 1000 },
+  },
+})
+`
+
+    expect(parseWorkerDefinition(source)).toEqual({
+      name: 'hello',
+      options: {
+        concurrency: 2,
+        lockDuration: 60_000,
+        limiter: { max: 10, duration: 1000 },
+      },
+    })
+  })
+
+  it('returns null when defineWorker is missing', () => {
+    expect(parseWorkerDefinition('export default {}')).toBeNull()
+  })
+
+  it('returns null when name is not a string literal', () => {
+    const source = `
+export default defineWorker({
+  name: workerName,
+  processor: async () => {},
+})
+`
+    expect(parseWorkerDefinition(source)).toBeNull()
+  })
+})

--- a/spec/utils/scan-worker-files.spec.ts
+++ b/spec/utils/scan-worker-files.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs'
+import os from 'node:os'
+import { scanWorkerFiles } from '../../src/utils/scan-worker-files'
+
+describe('scan-worker-files', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'scan-worker-files-'))
+  })
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+    catch {
+      // ignore cleanup error
+    }
+  })
+
+  it('finds files in a directory (ts/js/mjs)', async () => {
+    const dir = join('some', 'workers')
+    const absDir = join(tmpDir, dir)
+    mkdirSync(join(absDir, 'nested'), { recursive: true })
+    writeFileSync(join(absDir, 'a.ts'), 'export {}')
+    writeFileSync(join(absDir, 'b.js'), 'module.exports = {}')
+    writeFileSync(join(absDir, 'nested', 'c.mjs'), 'export {}')
+    writeFileSync(join(absDir, 'ignored.txt'), 'ignore')
+
+    const files = await scanWorkerFiles({
+      rootDir: tmpDir,
+      workersPath: dir,
+    })
+    expect(files.sort()).toEqual([
+      join(absDir, 'a.ts'),
+      join(absDir, 'b.js'),
+      join(absDir, 'nested', 'c.mjs'),
+    ].sort())
+  })
+
+  it('uses a custom pattern to limit extensions', async () => {
+    const dir = join('some', 'workers')
+    const absDir = join(tmpDir, dir)
+    mkdirSync(absDir, { recursive: true })
+    writeFileSync(join(absDir, 'a.ts'), 'export {}')
+    writeFileSync(join(absDir, 'b.js'), 'module.exports = {}')
+
+    const files = await scanWorkerFiles({
+      rootDir: tmpDir,
+      workersPath: dir,
+      pattern: '**/*.ts',
+    })
+    expect(files).toEqual([join(absDir, 'a.ts')])
+  })
+
+  it('supports extglob patterns to exclude spec files', async () => {
+    const dir = join('some', 'workers')
+    const absDir = join(tmpDir, dir)
+    mkdirSync(absDir, { recursive: true })
+    writeFileSync(join(absDir, 'worker.ts'), 'export {}')
+    writeFileSync(join(absDir, 'worker.spec.ts'), 'export {}')
+
+    const files = await scanWorkerFiles({
+      rootDir: tmpDir,
+      workersPath: dir,
+      pattern: '**/!(*.spec).ts',
+    })
+    expect(files).toEqual([join(absDir, 'worker.ts')])
+  })
+})

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,14 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { resolve } from 'pathe'
+import { loadNuxtConfig } from '@nuxt/kit'
 import { createMain, defineCommand } from 'citty'
 
 import ensureNuxtProject from './utils/ensure-nuxt-project'
 import { ensureProcessorDevScript } from './utils/ensure-processor-dev-script'
+import { buildWorkerManifest } from './utils/build-worker-manifest'
+import { resolveProcessorOptions } from './utils/cli/resolve-processor-options'
+import { parseWorkersArg, printWorkersManifest } from './utils/cli/print-workers-manifest'
 import { version, name, description } from '../package.json'
 import { logger } from './utils/logger'
 
@@ -90,6 +94,56 @@ export const main = createMain({
         child.on('exit', (code) => {
           process.exit(code ?? 0)
         })
+      },
+    }),
+    workers: defineCommand({
+      meta: {
+        name: 'workers',
+        description: 'Inspect discovered workers',
+      },
+      subCommands: {
+        list: defineCommand({
+          meta: {
+            name: 'list',
+            description: 'List workers discovered from source files',
+          },
+          args: {
+            dir: {
+              type: 'positional',
+              default: '.',
+            },
+            json: {
+              type: 'boolean',
+              description: 'Output the worker manifest as JSON',
+            },
+            workers: {
+              type: 'string',
+              description: 'Filter by worker names, comma-separated; use --workers=name1,name2',
+            },
+          },
+          async run({ args }) {
+            const dirArg = typeof args.dir === 'string' ? args.dir : '.'
+            await ensureNuxtProject({ global: false, dir: dirArg })
+
+            const projectRoot = resolve(dirArg)
+            const nuxtConfig = await loadNuxtConfig({ cwd: projectRoot })
+            const processorOptions = resolveProcessorOptions(nuxtConfig as unknown as Record<string, unknown>)
+            const selectedWorkers = parseWorkersArg(args.workers)
+
+            try {
+              const manifest = await buildWorkerManifest({
+                rootDir: projectRoot,
+                processorOptions,
+                selectedWorkers,
+              })
+              printWorkersManifest(manifest, Boolean(args.json))
+            }
+            catch (error) {
+              logger.error(error instanceof Error ? error.message : String(error))
+              process.exit(1)
+            }
+          },
+        }),
       },
     }),
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,6 +4,7 @@ import { buildRedisRuntimeConfig } from './utils/redis-runtime-config'
 import type { Plugin } from 'rollup'
 import { relative } from 'node:path'
 import scanFolder from './utils/scan-folder'
+import { DuplicateWorkerNameError, validateDiscoveredWorkers } from './utils/build-worker-manifest'
 import { generateWorkersEntryContent } from './utils/generate-workers-entry-content'
 import { generateWorkersIndexWrapper } from './utils/generate-workers-index-wrapper'
 
@@ -104,6 +105,22 @@ declare module '@nuxt/schema' {
             virtualCode = ''
             return
           }
+
+          try {
+            await validateDiscoveredWorkers({
+              rootDir: nuxt.options.rootDir,
+              processorOptions: _options,
+              workerFiles,
+            })
+          }
+          catch (error) {
+            if (error instanceof DuplicateWorkerNameError) {
+              this.error(error.message)
+              return
+            }
+            throw error
+          }
+
           virtualCode = generateWorkersEntryContent(workerFiles)
           for (const id of workerFiles) {
             this.addWatchFile(id)

--- a/src/utils/build-worker-manifest.ts
+++ b/src/utils/build-worker-manifest.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs'
+import { relative } from 'pathe'
+import { version } from '../../package.json'
+import type { ModuleOptions } from '../module'
+import { parseWorkerDefinition, type ParsedWorkerOptions } from './parse-worker-definition'
+import { scanWorkerFiles } from './scan-worker-files'
+import { logger } from './logger'
+
+export interface WorkerManifestEffectiveOptions {
+  concurrency: number
+  autorun: false
+  lockDuration: number
+  stalledInterval: number
+  maxStalledCount: number
+  limiter?: { max: number, duration: number }
+}
+
+export interface WorkerManifestEntry {
+  name: string
+  source: string
+  options: ParsedWorkerOptions
+  effective: WorkerManifestEffectiveOptions
+}
+
+export interface WorkerManifest {
+  version: string
+  workersPath: string
+  workersPattern: string
+  shutdown?: { timeoutMs: number }
+  selectedWorkers: string[] | null
+  workers: WorkerManifestEntry[]
+}
+
+export const BULLMQ_WORKER_DEFAULTS = {
+  concurrency: 1,
+  lockDuration: 30_000,
+  stalledInterval: 30_000,
+  maxStalledCount: 1,
+} as const
+
+export function buildEffectiveWorkerOptions(
+  options: ParsedWorkerOptions,
+): WorkerManifestEffectiveOptions {
+  const effective: WorkerManifestEffectiveOptions = {
+    concurrency: options.concurrency ?? BULLMQ_WORKER_DEFAULTS.concurrency,
+    autorun: false,
+    lockDuration: options.lockDuration ?? BULLMQ_WORKER_DEFAULTS.lockDuration,
+    stalledInterval: options.stalledInterval ?? BULLMQ_WORKER_DEFAULTS.stalledInterval,
+    maxStalledCount: options.maxStalledCount ?? BULLMQ_WORKER_DEFAULTS.maxStalledCount,
+  }
+
+  if (options.limiter) {
+    effective.limiter = options.limiter
+  }
+
+  return effective
+}
+
+export class DuplicateWorkerNameError extends Error {
+  constructor(
+    public readonly duplicates: Array<{ name: string, sources: string[] }>,
+  ) {
+    const details = duplicates
+      .map(d => `"${d.name}" in ${d.sources.join(', ')}`)
+      .join('; ')
+    super(`Duplicate worker names found: ${details}`)
+    this.name = 'DuplicateWorkerNameError'
+  }
+}
+
+export function assertNoDuplicateWorkerNames(
+  workers: Array<{ name: string, source: string }>,
+): void {
+  const byName = new Map<string, string[]>()
+
+  for (const worker of workers) {
+    const sources = byName.get(worker.name) ?? []
+    sources.push(worker.source)
+    byName.set(worker.name, sources)
+  }
+
+  const duplicates = [...byName.entries()]
+    .filter(([, sources]) => sources.length > 1)
+    .map(([name, sources]) => ({ name, sources }))
+
+  if (duplicates.length > 0) {
+    throw new DuplicateWorkerNameError(duplicates)
+  }
+}
+
+export interface BuildWorkerManifestOptions {
+  rootDir: string
+  processorOptions: ModuleOptions
+  workerFiles?: string[]
+  selectedWorkers?: string[] | null
+}
+
+async function collectWorkerEntries({
+  rootDir,
+  processorOptions,
+  workerFiles,
+}: BuildWorkerManifestOptions): Promise<WorkerManifestEntry[]> {
+  const workersPath = processorOptions.workers
+  const workersPattern = processorOptions.workersPattern ?? '**/*.{ts,js,mjs}'
+
+  const files = workerFiles ?? await scanWorkerFiles({
+    rootDir,
+    workersPath,
+    pattern: workersPattern,
+  })
+
+  const parsedWorkers: WorkerManifestEntry[] = []
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8')
+    const parsed = parseWorkerDefinition(source)
+    if (!parsed) {
+      logger.warn(`No defineWorker() call found in ${relative(rootDir, file)}`)
+      continue
+    }
+
+    parsedWorkers.push({
+      name: parsed.name,
+      source: relative(rootDir, file),
+      options: parsed.options,
+      effective: buildEffectiveWorkerOptions(parsed.options),
+    })
+  }
+
+  return parsedWorkers
+}
+
+export async function validateDiscoveredWorkers(
+  options: BuildWorkerManifestOptions,
+): Promise<void> {
+  const parsedWorkers = await collectWorkerEntries(options)
+  assertNoDuplicateWorkerNames(parsedWorkers)
+}
+
+export async function buildWorkerManifest({
+  rootDir,
+  processorOptions,
+  workerFiles,
+  selectedWorkers = null,
+}: BuildWorkerManifestOptions): Promise<WorkerManifest> {
+  const workersPath = processorOptions.workers
+  const workersPattern = processorOptions.workersPattern ?? '**/*.{ts,js,mjs}'
+
+  const parsedWorkers = await collectWorkerEntries({
+    rootDir,
+    processorOptions,
+    workerFiles,
+  })
+
+  assertNoDuplicateWorkerNames(parsedWorkers)
+
+  const filteredWorkers = selectedWorkers
+    ? parsedWorkers.filter(worker => selectedWorkers.includes(worker.name))
+    : parsedWorkers
+
+  const manifest: WorkerManifest = {
+    version,
+    workersPath,
+    workersPattern,
+    selectedWorkers,
+    workers: filteredWorkers,
+  }
+
+  if (processorOptions.shutdown?.timeoutMs !== undefined) {
+    manifest.shutdown = { timeoutMs: processorOptions.shutdown.timeoutMs }
+  }
+
+  return manifest
+}

--- a/src/utils/cli/print-workers-manifest.ts
+++ b/src/utils/cli/print-workers-manifest.ts
@@ -1,0 +1,34 @@
+import type { WorkerManifest } from '../build-worker-manifest'
+import { logger } from '../logger'
+
+export function parseWorkersArg(value: unknown): string[] | null {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null
+  }
+  return value.split(',').map(s => s.trim()).filter(Boolean)
+}
+
+export function printWorkersManifest(manifest: WorkerManifest, json: boolean) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`)
+    return
+  }
+
+  if (manifest.workers.length === 0) {
+    logger.info('No workers found.')
+    return
+  }
+
+  const rows = manifest.workers.map(worker => ({
+    name: worker.name,
+    source: worker.source,
+    concurrency: String(worker.effective.concurrency),
+  }))
+  const nameWidth = Math.max(4, ...rows.map(row => row.name.length))
+  const sourceWidth = Math.max(6, ...rows.map(row => row.source.length))
+  const header = `${'name'.padEnd(nameWidth)}  ${'source'.padEnd(sourceWidth)}  concurrency`
+  const lines = rows.map(row =>
+    `${row.name.padEnd(nameWidth)}  ${row.source.padEnd(sourceWidth)}  ${row.concurrency}`,
+  )
+  process.stdout.write(`${[header, ...lines].join('\n')}\n`)
+}

--- a/src/utils/cli/resolve-processor-options.ts
+++ b/src/utils/cli/resolve-processor-options.ts
@@ -1,0 +1,14 @@
+import { defu } from 'defu'
+import type { ModuleOptions } from '../../module'
+
+export const DEFAULT_PROCESSOR_OPTIONS: Required<Pick<ModuleOptions, 'workers' | 'workersPattern'>> & ModuleOptions = {
+  workers: 'server/workers',
+  workersPattern: '**/*.{ts,js,mjs}',
+}
+
+export function resolveProcessorOptions(
+  config: Record<string, unknown> | undefined,
+): ModuleOptions {
+  const processor = (config?.processor ?? {}) as ModuleOptions
+  return defu(processor, DEFAULT_PROCESSOR_OPTIONS) as ModuleOptions
+}

--- a/src/utils/generate-workers-entry-content.ts
+++ b/src/utils/generate-workers-entry-content.ts
@@ -19,8 +19,23 @@ try { process.stderr?.on?.('error', handleStreamError) } catch (err) { console.w
 const modules = [
 ${toImportArray}
 ]
+const logger = consola.create({}).withTag('nuxt-processor')
 for (const loader of modules) {
 await loader()
+}
+const registeredWorkers = Array.isArray(api.workers) ? api.workers : []
+const workerNameCounts = registeredWorkers.reduce((counts, worker) => {
+  if (worker?.name) {
+    counts.set(worker.name, (counts.get(worker.name) ?? 0) + 1)
+  }
+  return counts
+}, new Map())
+const duplicateWorkerNames = [...workerNameCounts.entries()]
+  .filter(([, count]) => count > 1)
+  .map(([name]) => name)
+if (duplicateWorkerNames.length > 0) {
+  logger.error('duplicate worker names found: ' + duplicateWorkerNames.join(', '))
+  process.exit(1)
 }
 // Parse --workers flag (e.g. --workers=basic,hello)
 const workersArg = process.argv.find(a => typeof a === 'string' && a.startsWith('--workers='))
@@ -30,7 +45,6 @@ const selectedWorkers = workersArg
 const workersToRun = selectedWorkers
   ? (Array.isArray(api.workers) ? api.workers.filter(w => w && selectedWorkers.includes(w.name)) : [])
   : (Array.isArray(api.workers) ? api.workers : [])
-const logger = consola.create({}).withTag('nuxt-processor')
 if (selectedWorkers && workersToRun.length === 0) {
   const available = (Array.isArray(api.workers) ? api.workers.map(w => w && w.name).filter(Boolean) : [])
   logger.warn('No workers matched --workers=' + selectedWorkers.join(',') + (available.length ? '. Available: ' + available.join(', ') : '.'))

--- a/src/utils/parse-worker-definition.ts
+++ b/src/utils/parse-worker-definition.ts
@@ -1,0 +1,281 @@
+export interface ParsedWorkerOptions {
+  concurrency?: number
+  limiter?: { max: number, duration: number }
+  lockDuration?: number
+  stalledInterval?: number
+  maxStalledCount?: number
+}
+
+export interface ParsedWorkerDefinition {
+  name: string
+  options: ParsedWorkerOptions
+}
+
+function findDefineWorkerCallIndex(source: string): number {
+  const match = source.match(/\bdefineWorker(?:<[^>]*>)?\s*\(/)
+  return match?.index ?? -1
+}
+
+function extractObjectLiteral(source: string, openBraceIndex: number): string | null {
+  if (source[openBraceIndex] !== '{') {
+    return null
+  }
+
+  let depth = 0
+  let inString: '"' | '\'' | '`' | null = null
+  let escaped = false
+
+  for (let i = openBraceIndex; i < source.length; i++) {
+    const char = source[i]
+
+    if (inString) {
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === inString) {
+        inString = null
+      }
+      continue
+    }
+
+    if (char === '"' || char === '\'' || char === '`') {
+      inString = char
+      continue
+    }
+
+    if (char === '{') {
+      depth++
+      continue
+    }
+
+    if (char === '}') {
+      depth--
+      if (depth === 0) {
+        return source.slice(openBraceIndex, i + 1)
+      }
+    }
+  }
+
+  return null
+}
+
+function parseStringLiteral(value: string): string | null {
+  const trimmed = value.trim()
+  const match = trimmed.match(/^(['"`])(.*)\1$/)
+  if (!match) {
+    return null
+  }
+  return match[2]
+}
+
+function parseNumberLiteral(value: string): number | null {
+  const trimmed = value.trim().replace(/_/g, '')
+  if (!/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+    return null
+  }
+  return Number(trimmed)
+}
+
+function extractPropertyObjectLiteral(objectLiteral: string, propertyName: string): string | null {
+  const pattern = new RegExp(`\\b${propertyName}:\\s*\\{`)
+  const match = pattern.exec(objectLiteral)
+  if (!match) {
+    return null
+  }
+
+  const openBraceIndex = objectLiteral.indexOf('{', match.index)
+  return extractObjectLiteral(objectLiteral, openBraceIndex)
+}
+
+function parseTopLevelObject(objectLiteral: string): Map<string, string> {
+  const inner = objectLiteral.slice(1, -1)
+  const entries = new Map<string, string>()
+  let depth = 0
+  let inString: '"' | '\'' | '`' | null = null
+  let escaped = false
+  let key = ''
+  let value = ''
+  let currentKey: string | null = null
+  let collectingKey = true
+
+  const flush = () => {
+    if (currentKey !== null) {
+      entries.set(currentKey, value.trim())
+    }
+    key = ''
+    value = ''
+    currentKey = null
+    collectingKey = true
+  }
+
+  for (let i = 0; i < inner.length; i++) {
+    const char = inner[i]
+
+    if (inString) {
+      if (collectingKey) {
+        key += char
+      }
+      else {
+        value += char
+      }
+
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === inString) {
+        inString = null
+      }
+      continue
+    }
+
+    if (char === '"' || char === '\'' || char === '`') {
+      inString = char
+      if (collectingKey) {
+        key += char
+      }
+      else {
+        value += char
+      }
+      continue
+    }
+
+    if (depth === 0) {
+      if (char === ':') {
+        if (collectingKey) {
+          currentKey = parseStringLiteral(key) ?? key.trim().replace(/^\[|\]$/g, '')
+          collectingKey = false
+        }
+        continue
+      }
+      if (char === ',') {
+        flush()
+        continue
+      }
+    }
+
+    if (collectingKey) {
+      key += char
+    }
+    else {
+      value += char
+    }
+
+    if (char === '{' || char === '[' || char === '(') {
+      depth++
+    }
+    else if (char === '}' || char === ']' || char === ')') {
+      depth--
+    }
+  }
+
+  flush()
+  return entries
+}
+
+function parseOptionsObject(value: string): ParsedWorkerOptions {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith('{')) {
+    return {}
+  }
+
+  const entries = parseTopLevelObject(trimmed)
+  const options: ParsedWorkerOptions = {}
+
+  const concurrency = entries.get('concurrency')
+  if (concurrency !== undefined) {
+    const parsed = parseNumberLiteral(concurrency)
+    if (parsed !== null) {
+      options.concurrency = parsed
+    }
+  }
+
+  const lockDuration = entries.get('lockDuration')
+  if (lockDuration !== undefined) {
+    const parsed = parseNumberLiteral(lockDuration)
+    if (parsed !== null) {
+      options.lockDuration = parsed
+    }
+  }
+
+  const stalledInterval = entries.get('stalledInterval')
+  if (stalledInterval !== undefined) {
+    const parsed = parseNumberLiteral(stalledInterval)
+    if (parsed !== null) {
+      options.stalledInterval = parsed
+    }
+  }
+
+  const maxStalledCount = entries.get('maxStalledCount')
+  if (maxStalledCount !== undefined) {
+    const parsed = parseNumberLiteral(maxStalledCount)
+    if (parsed !== null) {
+      options.maxStalledCount = parsed
+    }
+  }
+
+  const limiter = entries.get('limiter')
+  if (limiter?.trim().startsWith('{')) {
+    const limiterEntries = parseTopLevelObject(limiter.trim())
+    const max = limiterEntries.get('max')
+    const duration = limiterEntries.get('duration')
+    const parsedMax = max !== undefined ? parseNumberLiteral(max) : null
+    const parsedDuration = duration !== undefined ? parseNumberLiteral(duration) : null
+    if (parsedMax !== null && parsedDuration !== null) {
+      options.limiter = { max: parsedMax, duration: parsedDuration }
+    }
+  }
+
+  return options
+}
+
+function extractWorkerName(objectLiteral: string): string | null {
+  const match = objectLiteral.match(/\bname:\s*(['"`])([^'"`]+)\1/)
+  if (!match) {
+    return null
+  }
+  return match[2]
+}
+
+export function parseWorkerDefinition(source: string): ParsedWorkerDefinition | null {
+  const callIndex = findDefineWorkerCallIndex(source)
+  if (callIndex === -1) {
+    return null
+  }
+
+  const afterCall = source.slice(callIndex)
+  const openParenIndex = afterCall.indexOf('(')
+  if (openParenIndex === -1) {
+    return null
+  }
+
+  const argsStart = afterCall.slice(openParenIndex + 1)
+  const openBraceIndex = argsStart.indexOf('{')
+  if (openBraceIndex === -1) {
+    return null
+  }
+
+  const objectLiteral = extractObjectLiteral(argsStart, openBraceIndex)
+  if (!objectLiteral) {
+    return null
+  }
+
+  const name = extractWorkerName(objectLiteral)
+  if (!name) {
+    return null
+  }
+
+  const optionsLiteral = extractPropertyObjectLiteral(objectLiteral, 'options')
+  const options = optionsLiteral ? parseOptionsObject(optionsLiteral) : {}
+
+  return { name, options }
+}

--- a/src/utils/parse-worker-definition.ts
+++ b/src/utils/parse-worker-definition.ts
@@ -70,7 +70,7 @@ function parseStringLiteral(value: string): string | null {
   if (!match) {
     return null
   }
-  return match[2]
+  return match[2] ?? null
 }
 
 function parseNumberLiteral(value: string): number | null {
@@ -243,7 +243,7 @@ function extractWorkerName(objectLiteral: string): string | null {
   if (!match) {
     return null
   }
-  return match[2]
+  return match[2] ?? null
 }
 
 export function parseWorkerDefinition(source: string): ParsedWorkerDefinition | null {

--- a/src/utils/scan-folder.ts
+++ b/src/utils/scan-folder.ts
@@ -1,5 +1,5 @@
-import fg from 'fast-glob'
-import { createResolver, useNuxt } from '@nuxt/kit'
+import { useNuxt } from '@nuxt/kit'
+import { scanWorkerFiles } from './scan-worker-files'
 import { logger } from './logger'
 
 // Credit for this code to
@@ -13,19 +13,12 @@ export interface ScanFolderOptions {
 
 export default async ({ path, pattern = '**/*.{ts,js,mjs}' }: ScanFolderOptions): Promise<string[]> => {
   const nuxt = useNuxt()
-  const { resolve } = createResolver(import.meta.url)
-  // https://github.com/genu/nuxt-concierge/issues/8
-  const resolvedPath = resolve(nuxt.options.rootDir, path)
 
-  const files: string[] = []
-
-  const updatedFiles = await fg(pattern, {
-    cwd: resolvedPath,
-    absolute: true,
-    onlyFiles: true,
+  const files = await scanWorkerFiles({
+    rootDir: nuxt.options.rootDir,
+    workersPath: path,
+    pattern,
   })
-
-  files.push(...new Set(updatedFiles))
 
   if (files.length === 0) {
     logger.warn('No worker files found in project')

--- a/src/utils/scan-worker-files.ts
+++ b/src/utils/scan-worker-files.ts
@@ -1,0 +1,25 @@
+import fg from 'fast-glob'
+import { resolve } from 'pathe'
+
+export interface ScanWorkerFilesOptions {
+  rootDir: string
+  /** Path to the workers directory, relative to the project root. */
+  workersPath: string
+  pattern?: string
+}
+
+export async function scanWorkerFiles({
+  rootDir,
+  workersPath,
+  pattern = '**/*.{ts,js,mjs}',
+}: ScanWorkerFilesOptions): Promise<string[]> {
+  const resolvedPath = resolve(rootDir, workersPath)
+
+  const files = await fg(pattern, {
+    cwd: resolvedPath,
+    absolute: true,
+    onlyFiles: true,
+  })
+
+  return [...new Set(files)]
+}


### PR DESCRIPTION
## Summary

List what workers will be picked up via the cli with support for workers flag.

## Changes

- Adds workers list command to CLI
- Provides JSON output of workers that will be picked up by the module

## How to Test

1. Create worker files
2. Run the CLI command
3. Validate output

## Screenshots (optional)

n/a

## Linked Issues

Closes #64

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] I tested these changes locally
- [x] Added/updated tests if needed
- [x] Updated docs (README/docs) if needed
- [x] `npm run ci` passes (or `npm run lint` and `npm test` at minimum)
- [x] No breaking changes, or I documented them above